### PR TITLE
Remove UCI command bench

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -171,11 +171,6 @@ int main(int argc, char **argv) {
             fflush(stdout);
         }
 
-        else if (stringStartsWith(str, "bench")){
-            runBenchmark(threads, atoi(str + strlen("bench ")));
-            fflush(stdout);
-        }
-
         else if (stringStartsWith(str, "print")){
             printBoard(&board);
             fflush(stdout);


### PR DESCRIPTION
It's useless now that we can do it from command line. Anyway, this command was
bogus, because it doesn't restore a clean slate before benching. Simply running
2 bench in a row, gives different node counts.

No functional change.

BENCH : 9,025,559