### PR TITLE
Correct singular keys (9385381)

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -967,6 +967,9 @@ int moveIsSingular(Thread* thread, uint16_t ttMove, int ttValue, Undo* undo, int
     // Table move was already applied, undo that
     revertMove(board, ttMove, undo);
 
+    // We must use an orthogonal key space in the sub-tree, as we are doing a partial search
+    board->hash = ~board->hash;
+
     // Iterate and check all moves other than the table move
     initializeMovePicker(&movePicker, thread, NONE_MOVE, height, 0);
     while ((move = selectNextMove(&movePicker, board)) != NONE_MOVE){
@@ -990,6 +993,9 @@ int moveIsSingular(Thread* thread, uint16_t ttMove, int ttValue, Undo* undo, int
         // Move failed high, thus ttMove is not singular
         if (value > rBeta) break;
     }
+
+    // Retore key
+    board->hash = ~board->hash;
 
     // Reapply the table move we took off
     applyMove(board, ttMove, undo);

--- a/src/search.c
+++ b/src/search.c
@@ -968,7 +968,7 @@ int moveIsSingular(Thread* thread, uint16_t ttMove, int ttValue, Undo* undo, int
     revertMove(board, ttMove, undo);
 
     // We must use an orthogonal key space in the sub-tree, as we are doing a partial search
-    board->hash = ~board->hash;
+    board->hash ^= ttMove;
 
     // Iterate and check all moves other than the table move
     initializeMovePicker(&movePicker, thread, NONE_MOVE, height, 0);
@@ -995,7 +995,7 @@ int moveIsSingular(Thread* thread, uint16_t ttMove, int ttValue, Undo* undo, int
     }
 
     // Retore key
-    board->hash = ~board->hash;
+    board->hash ^= ttMove;
 
     // Reapply the table move we took off
     applyMove(board, ttMove, undo);


### PR DESCRIPTION
Can you try this on your framework ?

I can't really test it, because singular only kicks in at high depth, so is only mesurable at long tc. and with my puny testing resources (just a quad), it would either take for ever, or i'd have to sacrifice testing resolution...

On the one hand, this is more theoretically correct. But on the other hand, even with wrong tt hit, we could still have a benefit to to improved move ordering etc. So it's not clear where the tradeoff lies.