### PR TITLE
Increase time also for smaller score jumps

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -111,6 +111,10 @@ void updateTimeManagment(SearchInfo* info, Limits* limits, int depth, int value)
         info->idealUsage *= 1.050;
 
     // Increase our time if the score suddenly jumps
+    if (info->values[depth-1] + 15 < value)
+        info->idealUsage *= 1.025;
+
+    // Increase our time if the score suddenly jumps
     if (info->values[depth-1] + 30 < value)
         info->idealUsage *= 1.050;
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -21,7 +21,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "10.82"
+#define VERSION_ID "10.83"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 2.50 +- 2.00 (95%)
SPRT&nbsp;&nbsp;&nbsp;&nbsp;| 60.0+0.6s Threads=1 Hash=64MB
LLR&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 38460 W: 6537 L: 6260 D: 25663

ELO&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 3.21 +- 2.58 (95%)
SPRT&nbsp;&nbsp;&nbsp;&nbsp;| 40/40.0s Threads=1 Hash=64MB
LLR&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24870 W: 4564 L: 4334 D: 15972

ELO&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 2.34 +- 3.52 (95%)
SPRT&nbsp;&nbsp;&nbsp;&nbsp;| 240.0+2.4s Threads=1 Hash=128MB
LLR&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| 1.70 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 10550 W: 1528 L: 1457 D: 7565