### PR TITLE
Simplify safe queenChecks

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -680,13 +680,12 @@ int evaluateKings(EvalInfo *ei, Board *board, int colour) {
         uint64_t rookThreats   = rookAttacks(kingSq, occupied);
         uint64_t queenThreats  = bishopThreats | rookThreats;
 
-        // Identify if pieces can move to those checking squares safely.
-        // We check if our Queen can attack the square for safe Queen checks.
-        // No attacks of other pieces is implicit in our definition of weak.
-        uint64_t knightChecks = knightThreats & safe &  ei->attackedBy[THEM][KNIGHT];
-        uint64_t bishopChecks = bishopThreats & safe &  ei->attackedBy[THEM][BISHOP];
-        uint64_t rookChecks   = rookThreats   & safe &  ei->attackedBy[THEM][ROOK  ];
-        uint64_t queenChecks  = queenThreats  & safe &  ei->attackedBy[THEM][QUEEN ];
+        // Identify if there are pieces which can move to the checking squares safely.
+        // We consider forking a Queen to be a safe check, even with our own Queen.
+        uint64_t knightChecks = knightThreats & safe & ei->attackedBy[THEM][KNIGHT];
+        uint64_t bishopChecks = bishopThreats & safe & ei->attackedBy[THEM][BISHOP];
+        uint64_t rookChecks   = rookThreats   & safe & ei->attackedBy[THEM][ROOK  ];
+        uint64_t queenChecks  = queenThreats  & safe & ei->attackedBy[THEM][QUEEN ];
 
         count  = ei->kingAttackersCount[THEM] * ei->kingAttackersWeight[THEM];
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -686,8 +686,7 @@ int evaluateKings(EvalInfo *ei, Board *board, int colour) {
         uint64_t knightChecks = knightThreats & safe &  ei->attackedBy[THEM][KNIGHT];
         uint64_t bishopChecks = bishopThreats & safe &  ei->attackedBy[THEM][BISHOP];
         uint64_t rookChecks   = rookThreats   & safe &  ei->attackedBy[THEM][ROOK  ];
-        uint64_t queenChecks  = queenThreats  & safe &  ei->attackedBy[THEM][QUEEN ]
-                                                     & ~ei->attackedBy[  US][QUEEN ];
+        uint64_t queenChecks  = queenThreats  & safe &  ei->attackedBy[THEM][QUEEN ];
 
         count  = ei->kingAttackersCount[THEM] * ei->kingAttackersWeight[THEM];
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -21,7 +21,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.06"
+#define VERSION_ID "11.07"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO &nbsp;&nbsp;&nbsp; | 0.08 +- 1.61 (95%)
SPRT &nbsp;&nbsp; | 10.0+0.1s Threads=1 Hash=8MB
LLR &nbsp;&nbsp;&nbsp;&nbsp; | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 75930 W: 16090 L: 16073 D: 43767

ELO &nbsp;&nbsp;&nbsp; | 0.88 +- 2.01 (95%)
SPRT &nbsp;&nbsp; | 60.0+0.6s Threads=1 Hash=64MB
LLR &nbsp;&nbsp;&nbsp;&nbsp; | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 37630 W: 6238 L: 6143 D: 25249

BENCH: 5,826,994