### PR TITLE
Passer king distance rank based

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -226,9 +226,9 @@ const int PassedPawn[2][2][8] = {
     S(  -1, 101), S(  44, 223), S( 125, 381), S(   0,   0)}},
 };
 
-const int PassedFriendlyDistance = S(   4,  -6);
+const int PassedFriendlyDistance[] = {0, 0, 0, S(0,-3), S(0,-13), S(0,-24), S(0,-33)};
 
-const int PassedEnemyDistance = S(  -1,   8);
+const int PassedEnemyDistance[] = {0, 0, 0, S(0,6), S(0,27), S(0,48), S(0,67)};
 
 const int PassedSafePromotionPath = S(   0,  26);
 
@@ -760,12 +760,12 @@ int evaluatePassedPawns(EvalInfo* ei, Board* board, int colour){
 
         // Evaluate based on distance from our king
         dist = distanceBetween(sq, ei->kingSquare[US]);
-        eval += dist * PassedFriendlyDistance;
+        eval += dist * PassedFriendlyDistance[rank];
         if (TRACE) T.PassedFriendlyDistance[US] += dist;
 
         // Evaluate based on distance from their king
         dist = distanceBetween(sq, ei->kingSquare[THEM]);
-        eval += dist * PassedEnemyDistance;
+        eval += dist * PassedEnemyDistance[rank];
         if (TRACE) T.PassedEnemyDistance[US] += dist;
 
         // Apply a bonus when the path to promoting is uncontested

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -226,9 +226,9 @@ const int PassedPawn[2][2][8] = {
     S(  -1, 101), S(  44, 223), S( 125, 381), S(   0,   0)}},
 };
 
-const int PassedFriendlyDistance[] = {0, 0, 0, S(0,-3), S(0,-13), S(0,-24), S(0,-33)};
+const int PassedFriendlyDistance[] = {0, 0, 0, S(0,-4), S(0,-8), S(0,-12), S(0,-16)};
 
-const int PassedEnemyDistance[] = {0, 0, 0, S(0,6), S(0,27), S(0,48), S(0,67)};
+const int PassedEnemyDistance[] = {0, 0, 0, S(0,8), S(0,16), S(0,24), S(0,32)};
 
 const int PassedSafePromotionPath = S(   0,  26);
 


### PR DESCRIPTION
ELO   | 2.77 +- 2.17 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 42140 W: 9236 L: 8900 D: 24004
http://chess.grantnet.us/viewTest/2489/
    
ELO   | 2.26 +- 1.74 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 52040 W: 9012 L: 8674 D: 34354
http://chess.grantnet.us/viewTest/2490/

Bench : 6,272,018