### PR TITLE
Introduce endgame complexity bonus/penalty

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -113,6 +113,7 @@ int evaluateKings(EvalInfo *ei, Board *board, int colour);
 int evaluatePassed(EvalInfo *ei, Board *board, int colour);
 int evaluateThreats(EvalInfo *ei, Board *board, int colour);
 int evaluateScaleFactor(Board *board);
+int complexity(EvalInfo *ei, Board *board, int eval);
 void initEvalInfo(EvalInfo *ei, Board *board, PKTable *pktable);
 void initEval();
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.58"
+#define VERSION_ID "11.59"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
In many endgames, the advantage of the better side is too small to convert. This patch looks for some common features related to conversion chances in order to better separate drawish endgames from winnable endgames.

Original idea from Stockfish, whose initiative code served as a base to simplify and adapt to Ethereal.

```
ELO   | 6.65 +- 4.59 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8825 W: 1861 L: 1692 D: 5272
http://chess.grantnet.us/viewTest/3471/
```

```
ELO   | 12.01 +- 6.05 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3965 W: 690 L: 553 D: 2722
http://chess.grantnet.us/viewTest/3472/
```

BENCH : 7,303,371