### PR TITLE
Use file distance to the closest pawn to score kings

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -65,6 +65,7 @@ struct EvalTrace {
     int RookOnSeventh[COLOUR_NB];
     int RookMobility[15][COLOUR_NB];
     int QueenMobility[28][COLOUR_NB];
+    int KingPawnFileProximity[8][COLOUR_NB];
     int KingDefenders[12][COLOUR_NB];
     int KingShelter[2][8][8][COLOUR_NB];
     int KingStorm[2][4][8][COLOUR_NB];

--- a/src/masks.h
+++ b/src/masks.h
@@ -25,6 +25,7 @@
 void initMasks();
 
 int distanceBetween(int sq1, int sq2);
+int kingPawnFileDistance(uint64_t pawns, int ksq);
 uint64_t bitsBetweenMasks(int sq1, int sq2);
 uint64_t kingAreaMasks(int colour, int sq);
 uint64_t forwardRanksMasks(int colour, int rank);

--- a/src/texel.c
+++ b/src/texel.c
@@ -72,6 +72,7 @@ extern const int RookFile[2];
 extern const int RookOnSeventh;
 extern const int RookMobility[15];
 extern const int QueenMobility[28];
+extern const int KingPawnFileProximity[8];
 extern const int KingDefenders[12];
 extern const int KingShelter[2][8][8];
 extern const int KingStorm[2][4][8];

--- a/src/texel.h
+++ b/src/texel.h
@@ -25,7 +25,7 @@
 #define KPRECISION  (     10) // Iterations for computing K
 #define NPARTITIONS (     64) // Total thread partitions
 #define REPORTING   (     25) // How often to report progress
-#define NTERMS      (      0) // Total terms in the Tuner (593)
+#define NTERMS      (      0) // Total terms in the Tuner (601)
 
 #define LEARNING    (    1.0) // Learning rate
 #define LRDROPRATE  (   1.25) // Cut LR by this each failure
@@ -63,6 +63,7 @@
 #define TuneRookOnSeventh               (0)
 #define TuneRookMobility                (0)
 #define TuneQueenMobility               (0)
+#define TuneKingPawnFileProximity       (0)
 #define TuneKingDefenders               (0)
 #define TuneKingShelter                 (0)
 #define TuneKingStorm                   (0)
@@ -251,6 +252,7 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_0(fname, RookOnSeventh, NORMAL);                     \
     ENABLE_1(fname, RookMobility, 15, NORMAL);                  \
     ENABLE_1(fname, QueenMobility, 28, NORMAL);                 \
+    ENABLE_1(fname, KingPawnFileProximity, 8, NORMAL);          \
     ENABLE_1(fname, KingDefenders, 12, NORMAL);                 \
     ENABLE_3(fname, KingShelter, 2, 8, 8, NORMAL);              \
     ENABLE_3(fname, KingStorm, 2, 4, 8, NORMAL);                \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.61"
+#define VERSION_ID "11.62"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
In endgames with pawns, kings need to either defend their own pawns, block enemy passers or threaten capture. Thus, kings too far away from any pawns are weaker. File distance is used as the most relevant measure of a king's ability to stop or help a passed pawn. Idea loosely inspired by Stockfish's pawnless flank concept.

Speed optimization by Andrew Grant.

ELO   | 8.27 +- 5.17 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6850 W: 1435 L: 1272 D: 4143
http://chess.grantnet.us/viewTest/3490/

ELO   | 7.58 +- 4.57 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6650 W: 1071 L: 926 D: 4653
http://chess.grantnet.us/viewTest/3491/

BENCH : 6,906,487