### PR TITLE
Evaluate differently stacked pawns that may be unstacked

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -50,7 +50,7 @@ struct EvalTrace {
     int KingPSQT32[32][COLOUR_NB];
     int PawnCandidatePasser[2][8][COLOUR_NB];
     int PawnIsolated[COLOUR_NB];
-    int PawnStacked[COLOUR_NB];
+    int PawnStacked[2][COLOUR_NB];
     int PawnBackwards[2][COLOUR_NB];
     int PawnConnected32[32][COLOUR_NB];
     int KnightOutpost[2][COLOUR_NB];

--- a/src/masks.c
+++ b/src/masks.c
@@ -30,6 +30,7 @@ int KingPawnFileDistance[FILE_NB][1 << FILE_NB];
 uint64_t BitsBetweenMasks[SQUARE_NB][SQUARE_NB];
 uint64_t KingAreaMasks[COLOUR_NB][SQUARE_NB];
 uint64_t ForwardRanksMasks[COLOUR_NB][RANK_NB];
+uint64_t ForwardFileMasks[COLOUR_NB][SQUARE_NB];
 uint64_t AdjacentFilesMasks[FILE_NB];
 uint64_t PassedPawnMasks[COLOUR_NB][SQUARE_NB];
 uint64_t PawnConnectedMasks[COLOUR_NB][SQUARE_NB];
@@ -100,6 +101,12 @@ void initMasks() {
         ForwardRanksMasks[BLACK][rank] = ~ForwardRanksMasks[WHITE][rank] | Ranks[rank];
     }
 
+    // Init a table of bitmasks for the squares on a file above a given square, by colour
+    for (int sq = 0; sq < SQUARE_NB; sq++) {
+        ForwardFileMasks[WHITE][sq] = Files[fileOf(sq)] & ForwardRanksMasks[WHITE][rankOf(sq)];
+        ForwardFileMasks[BLACK][sq] = Files[fileOf(sq)] & ForwardRanksMasks[BLACK][rankOf(sq)];
+    }
+
     // Init a table of bitmasks containing the files next to a given file
     for (int file = 0; file < FILE_NB; file++) {
         AdjacentFilesMasks[file]  = Files[MAX(0, file-1)];
@@ -159,6 +166,12 @@ uint64_t forwardRanksMasks(int colour, int rank) {
     assert(0 <= colour && colour < COLOUR_NB);
     assert(0 <= rank && rank < RANK_NB);
     return ForwardRanksMasks[colour][rank];
+}
+
+uint64_t forwardFileMasks(int colour, int sq) {
+    assert(0 <= colour && colour < COLOUR_NB);
+    assert(0 <= sq && sq < SQUARE_NB);
+    return ForwardFileMasks[colour][sq];
 }
 
 uint64_t adjacentFilesMasks(int file) {

--- a/src/masks.h
+++ b/src/masks.h
@@ -29,6 +29,7 @@ int kingPawnFileDistance(uint64_t pawns, int ksq);
 uint64_t bitsBetweenMasks(int sq1, int sq2);
 uint64_t kingAreaMasks(int colour, int sq);
 uint64_t forwardRanksMasks(int colour, int rank);
+uint64_t forwardFileMasks(int colour, int sq);
 uint64_t adjacentFilesMasks(int file);
 uint64_t passedPawnMasks(int colour, int sq);
 uint64_t pawnConnectedMasks(int colour, int sq);

--- a/src/move.c
+++ b/src/move.c
@@ -497,7 +497,7 @@ int moveWasLegal(Board *board) {
     return !squareIsAttacked(board, !board->turn, sq);
 }
 
-int moveIsPsuedoLegal(Board *board, uint16_t move) {
+int moveIsPseudoLegal(Board *board, uint16_t move) {
 
     int from   = MoveFrom(move);
     int type   = MoveType(move);
@@ -582,7 +582,7 @@ int moveIsPsuedoLegal(Board *board, uint16_t move) {
 
     // Verifying a castle move can be difficult, so instead we will just
     // attempt to generate the (two) possible castle moves for the given
-    // player. If one matches, we can then verify the psuedo legality
+    // player. If one matches, we can then verify the pseudo legality
     // using the same code as from movegen.c
 
     while (castles && !board->kingAttackers) {

--- a/src/move.h
+++ b/src/move.h
@@ -56,7 +56,7 @@ void revertNullMove(Board *board, Undo *undo);
 int moveIsTactical(Board *board, uint16_t move);
 int moveEstimatedValue(Board *board, uint16_t move);
 int moveBestCaseValue(Board *board);
-int moveIsPsuedoLegal(Board *board, uint16_t move);
+int moveIsPseudoLegal(Board *board, uint16_t move);
 int moveWasLegal(Board *board);
 void moveToString(uint16_t move, char *str, int chess960);
 

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -86,18 +86,18 @@ static void buildKingMoves(uint16_t *moves, int *size, uint64_t pieces, uint64_t
 void genAllLegalMoves(Board *board, uint16_t *moves, int *size) {
 
     Undo undo[1];
-    int psuedoSize = 0;
-    uint16_t psuedoMoves[MAX_MOVES];
+    int pseudoSize = 0;
+    uint16_t pseudoMoves[MAX_MOVES];
 
     // Call genAllNoisyMoves() & genAllNoisyMoves()
-    genAllNoisyMoves(board, psuedoMoves, &psuedoSize);
-    genAllQuietMoves(board, psuedoMoves, &psuedoSize);
+    genAllNoisyMoves(board, pseudoMoves, &pseudoSize);
+    genAllQuietMoves(board, pseudoMoves, &pseudoSize);
 
     // Check each move for legality before copying
-    for (int i = 0; i < psuedoSize; i++) {
-        applyMove(board, psuedoMoves[i], undo);
-        if (moveWasLegal(board)) moves[(*size)++] = psuedoMoves[i];
-        revertMove(board, psuedoMoves[i], undo);
+    for (int i = 0; i < pseudoSize; i++) {
+        applyMove(board, pseudoMoves[i], undo);
+        if (moveWasLegal(board)) moves[(*size)++] = pseudoMoves[i];
+        revertMove(board, pseudoMoves[i], undo);
     }
 }
 

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -121,9 +121,9 @@ uint16_t selectNextMove(MovePicker *mp, Board *board, int skipQuiets) {
 
         case STAGE_TABLE:
 
-            // Play table move if it is psuedo legal
+            // Play table move if it is pseudo legal
             mp->stage = STAGE_GENERATE_NOISY;
-            if (moveIsPsuedoLegal(board, mp->tableMove))
+            if (moveIsPseudoLegal(board, mp->tableMove))
                 return mp->tableMove;
 
             /* fallthrough */
@@ -187,35 +187,35 @@ uint16_t selectNextMove(MovePicker *mp, Board *board, int skipQuiets) {
 
         case STAGE_KILLER_1:
 
-            // Play killer move if not yet played, and psuedo legal
+            // Play killer move if not yet played, and pseudo legal
             mp->stage = STAGE_KILLER_2;
             if (   !skipQuiets
                 &&  mp->killer1 != mp->tableMove
-                &&  moveIsPsuedoLegal(board, mp->killer1))
+                &&  moveIsPseudoLegal(board, mp->killer1))
                 return mp->killer1;
 
             /* fallthrough */
 
         case STAGE_KILLER_2:
 
-            // Play killer move if not yet played, and psuedo legal
+            // Play killer move if not yet played, and pseudo legal
             mp->stage = STAGE_COUNTER_MOVE;
             if (   !skipQuiets
                 &&  mp->killer2 != mp->tableMove
-                &&  moveIsPsuedoLegal(board, mp->killer2))
+                &&  moveIsPseudoLegal(board, mp->killer2))
                 return mp->killer2;
 
             /* fallthrough */
 
         case STAGE_COUNTER_MOVE:
 
-            // Play counter move if not yet played, and psuedo legal
+            // Play counter move if not yet played, and pseudo legal
             mp->stage = STAGE_GENERATE_QUIET;
             if (   !skipQuiets
                 &&  mp->counter != mp->tableMove
                 &&  mp->counter != mp->killer1
                 &&  mp->counter != mp->killer2
-                &&  moveIsPsuedoLegal(board, mp->counter))
+                &&  moveIsPseudoLegal(board, mp->counter))
                 return mp->counter;
 
             /* fallthrough */

--- a/src/texel.c
+++ b/src/texel.c
@@ -57,7 +57,7 @@ extern const int QueenPSQT32[32];
 extern const int KingPSQT32[32];
 extern const int PawnCandidatePasser[2][8];
 extern const int PawnIsolated;
-extern const int PawnStacked;
+extern const int PawnStacked[2];
 extern const int PawnBackwards[2];
 extern const int PawnConnected32[32];
 extern const int KnightOutpost[2];

--- a/src/texel.h
+++ b/src/texel.h
@@ -25,7 +25,7 @@
 #define KPRECISION  (     10) // Iterations for computing K
 #define NPARTITIONS (     64) // Total thread partitions
 #define REPORTING   (     25) // How often to report progress
-#define NTERMS      (      0) // Total terms in the Tuner (600)
+#define NTERMS      (      0) // Total terms in the Tuner (601)
 
 #define LEARNING    (    1.0) // Learning rate
 #define LRDROPRATE  (   1.25) // Cut LR by this each failure
@@ -236,7 +236,7 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_1(fname, KingPSQT32, 32, NORMAL);                    \
     ENABLE_2(fname, PawnCandidatePasser, 2, 8, NORMAL);         \
     ENABLE_0(fname, PawnIsolated, NORMAL);                      \
-    ENABLE_0(fname, PawnStacked, NORMAL);                       \
+    ENABLE_1(fname, PawnStacked, 2, NORMAL);                    \
     ENABLE_1(fname, PawnBackwards, 2, NORMAL);                  \
     ENABLE_1(fname, PawnConnected32, 32, NORMAL);               \
     ENABLE_1(fname, KnightOutpost, 2, NORMAL);                  \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.64"
+#define VERSION_ID "11.65"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Doubled pawns are less of an issue if enemy pawn pushes would allow unstacking, or if the stacked pawns have a neighbor that allows to force unstacking.

Forward file masks and tuning by Andrew Grant.

Miscellaneous typo fixes.

ELO   | 3.41 +- 2.72 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 25350 W: 5276 L: 5027 D: 15047
http://chess.grantnet.us/viewTest/3532/

ELO   | 1.98 +- 1.50 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 62450 W: 9669 L: 9314 D: 43467
http://chess.grantnet.us/viewTest/3533/

BENCH : 6,840,525