### PR TITLE
Scale eval to draw with a lone minor

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -344,7 +344,7 @@ int evaluateBoard(Board *board, PKTable *pktable) {
     phase = (phase * 256 + 12) / 24;
 
     // Scale evaluation based on remaining material
-    factor = evaluateScaleFactor(board);
+    factor = evaluateScaleFactor(board, eval);
 
     // Compute the interpolated and scaled evaluation
     eval = (ScoreMG(eval) * (256 - phase)
@@ -935,7 +935,7 @@ int evaluateThreats(EvalInfo *ei, Board *board, int colour) {
     return eval;
 }
 
-int evaluateScaleFactor(Board *board) {
+int evaluateScaleFactor(Board *board, int eval) {
 
     // Scale endgames based on remaining material. Currently, we only
     // look for OCB endgames that include only one Knight or one Rook
@@ -964,6 +964,14 @@ int evaluateScaleFactor(Board *board) {
             && onlyOne(black & rooks))
             return SCALE_OCB_ONE_ROOK;
     }
+
+    int eg = ScoreEG(eval);
+
+    // Lone minor vs king and pawns, never give the advantage to the side with the minor
+    if ( (eg > 0) && popcount(white) == 2 && (white & (knights | bishops)))
+        return SCALE_DRAW;
+    else if ( (eg < 0) && popcount(black) == 2 && (black & (knights | bishops)))
+        return SCALE_DRAW;
 
     return SCALE_NORMAL;
 }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -32,6 +32,7 @@ enum {
     SCALE_OCB_BISHOPS_ONLY =  64,
     SCALE_OCB_ONE_KNIGHT   = 106,
     SCALE_OCB_ONE_ROOK     =  96,
+    SCALE_DRAW             =   0,
     SCALE_NORMAL           = 128,
 };
 
@@ -117,7 +118,7 @@ int evaluateQueens(EvalInfo *ei, Board *board, int colour);
 int evaluateKings(EvalInfo *ei, Board *board, int colour);
 int evaluatePassed(EvalInfo *ei, Board *board, int colour);
 int evaluateThreats(EvalInfo *ei, Board *board, int colour);
-int evaluateScaleFactor(Board *board);
+int evaluateScaleFactor(Board *board, int eval);
 int evaluateComplexity(EvalInfo *ei, Board *board, int eval);
 void initEvalInfo(EvalInfo *ei, Board *board, PKTable *pktable);
 void initEval();


### PR DESCRIPTION
In >99,9% of positions with a minor against a king and pawns, the side with the minor can at best get a draw, but the raw eval is frequently +1 to +2 for the side with the minor. Scaling this down helps ensuring that a winning line is not discarded in favor of such a draw.

ELO   | 2.53 +- 1.96 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 49225 W: 10216 L: 9857 D: 29152
http://chess.grantnet.us/viewTest/3592/

ELO   | 1.70 +- 1.15 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 106150 W: 16420 L: 15901 D: 73829
http://chess.grantnet.us/viewTest/3593/

BENCH : 7,041,633