### PR TITLE
Add TT bucket locking

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -16,7 +16,7 @@
 
 CC      = gcc
 SRC     = *.c fathom/tbprobe.c
-LIBS    = -lpthread -lm
+LIBS    = -lpthread -latomic -lm
 EXE     = Ethereal
 
 WFLAGS = -std=gnu11 -Wall -Wextra -Wshadow
@@ -43,6 +43,7 @@ release:
 	$(CC) $(RFLAGS) $(SRC) $(LIBS) -o ../dist/$(EXE)$(VER)-x64-nopopcnt.exe
 	$(CC) $(RFLAGS) $(SRC) $(LIBS) $(POPCNTFLAGS) -o ../dist/$(EXE)$(VER)-x64-popcnt.exe
 	$(CC) $(RFLAGS) $(SRC) $(LIBS) $(PEXTFLAGS) -o ../dist/$(EXE)$(VER)-x64-pext.exe
+	$(CC) $(RFLAGS) $(SRC) $(LIBS) $(PEXTFLAGS) -DNO_TT_LOCKS -o ../dist/$(EXE)$(VER)-x64-pext-nolocks.exe
 
 texel:
 	$(CC) $(TFLAGS) $(SRC) $(LIBS) $(POPCNT) -o $(EXE)

--- a/src/search.c
+++ b/src/search.c
@@ -212,6 +212,9 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
     if (depth <= 0 && !board->kingAttackers)
         return qsearch(thread, pv, alpha, beta, height);
 
+    // Prefetch TT as early as reasonable
+    prefetchTTEntry(board->hash);
+
     // Ensure a fresh PV
     pv->length = 0;
 
@@ -544,6 +547,9 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
         }
     }
 
+    // Prefetch TT for store
+    prefetchTTEntry(board->hash);
+
     // Step 18. Stalemate and Checkmate detection. If no moves were found to
     // be legal (search makes sure to play at least one legal move, if any),
     // then we are either mated or stalemated, which we can tell by the inCheck
@@ -575,6 +581,9 @@ int qsearch(Thread *thread, PVariation *pv, int alpha, int beta, int height) {
     uint16_t move, ttMove = NONE_MOVE;
     MovePicker movePicker;
     PVariation lpv;
+
+    // Prefetch TT as early as reasonable
+    prefetchTTEntry(board->hash);
 
     // Ensure a fresh PV
     pv->length = 0;

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -106,6 +106,12 @@ int valueToTT(int value, int height) {
          : value <= MATED_IN_MAX ? value - height : value;
 }
 
+void prefetchTTEntry(uint64_t hash)
+{
+    TTBucket *bucket = &Table.buckets[hash & Table.hashMask];
+    __builtin_prefetch(bucket);
+}
+
 int getTTEntry(uint64_t hash, uint16_t *move, int *value, int *eval, int *depth, int *bound) {
 
     const uint16_t hash16 = hash >> 48;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -75,6 +75,7 @@ void clearTT();
 int hashfullTT();
 int valueFromTT(int value, int height);
 int valueToTT(int value, int height);
+void prefetchTTEntry(uint64_t hash);
 int getTTEntry(uint64_t hash, uint16_t *move, int *value, int *eval, int *depth, int *bound);
 void storeTTEntry(uint64_t hash, uint16_t move, int value, int eval, int depth, int bound);
 


### PR DESCRIPTION
This patch makes Ethereal essentially free from data races as observed
by "clang -fsanitize=thread". The left-overs deal with collecting node
counter statistics, but those are not important for correct operation.

The performance penalty for locking is around 2% on my core i7-8700K.

We'll also add TT prefetching and allocate the hash with huge pages.
This more than gives back the lost performance by locking on my box.
Also, we'll keep producing the no-locks binary for people who prefer
the minor speed gain over race-free TT access.

Quick benchmark runs on my box: (3 runs, min..max nps, ethereal/master
refers to parent of this patch, ttbucket-lock is this patch, nolocks is
the nolocks binary by this patch.)

                   ethereal/master-pext   ttbucket-lock-pext   ttbucket-lock-nolocks
bench              3022128 ..3077096      3126860 ..3131684    3158482 ..3186992
bench 18 12        20428374..21549484     21090285..22159732   21863099..22031597
bench 18 12 16384  13087816..13480222     14784966..15247094   14317683..16348355

NO FUNCTIONAL CHANGE

BENCH 8,120,458