### PR TITLE
Multi cut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -494,9 +494,15 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
         // an early move has excellent continuation history, or when we have a move
         // from the transposition table which appears to beat all other moves by a
         // relativly large margin,
+        int multiCut = 0;
         extension =  (inCheck)
                   || (isQuiet && quietsSeen <= 4 && cmhist >= 10000 && fmhist >= 10000)
-                  || (singular && moveIsSingular(thread, ttMove, ttValue, depth, height));
+                  || (singular && moveIsSingular(thread, ttMove, ttValue, depth, height, beta, &multiCut));
+
+        if (!RootNode && multiCut) {
+            revert(thread, board, move, height);
+            return ttValue - depth;
+        }
 
         // Factor the extension into the new depth. Do not extend at the root
         newDepth = depth + (extension && !RootNode);
@@ -757,7 +763,7 @@ int staticExchangeEvaluation(Board *board, uint16_t move, int threshold) {
     return board->turn != colour;
 }
 
-int moveIsSingular(Thread *thread, uint16_t ttMove, int ttValue, int depth, int height) {
+int moveIsSingular(Thread *thread, uint16_t ttMove, int ttValue, int depth, int height, int beta, int *multiCut) {
 
     Board *const board = &thread->board;
 
@@ -797,6 +803,8 @@ int moveIsSingular(Thread *thread, uint16_t ttMove, int ttValue, int depth, int 
 
     // Reapply the table move we took off
     applyLegal(thread, board, ttMove, height);
+
+    *multiCut = value >= beta;
 
     // Move is singular if all other moves failed low
     return value <= rBeta;

--- a/src/search.c
+++ b/src/search.c
@@ -501,7 +501,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
 
         if (multiCut) {
             revert(thread, board, move, height);
-            return ttValue - depth;
+            return MAX(ttValue - depth, -MATE);
         }
 
         // Factor the extension into the new depth. Do not extend at the root

--- a/src/search.c
+++ b/src/search.c
@@ -499,7 +499,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
                   || (isQuiet && quietsSeen <= 4 && cmhist >= 10000 && fmhist >= 10000)
                   || (singular && moveIsSingular(thread, ttMove, ttValue, depth, height, beta, &multiCut));
 
-        if (!RootNode && multiCut) {
+        if (multiCut) {
             revert(thread, board, move, height);
             return ttValue - depth;
         }
@@ -804,7 +804,7 @@ int moveIsSingular(Thread *thread, uint16_t ttMove, int ttValue, int depth, int 
     // Reapply the table move we took off
     applyLegal(thread, board, ttMove, height);
 
-    *multiCut = value >= beta;
+    *multiCut = value >= rBeta && rBeta >= beta;
 
     // Move is singular if all other moves failed low
     return value <= rBeta;

--- a/src/search.h
+++ b/src/search.h
@@ -41,7 +41,7 @@ void aspirationWindow(Thread *thread);
 int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int height);
 int qsearch(Thread *thread, PVariation *pv, int alpha, int beta, int height);
 int staticExchangeEvaluation(Board *board, uint16_t move, int threshold);
-int moveIsSingular(Thread *thread, uint16_t ttMove, int ttValue, int depth, int height);
+int moveIsSingular(Thread *thread, uint16_t ttMove, int ttValue, int depth, int height, int beta, int *multiCut);
 
 static const int SMPCycles      = 16;
 static const int SkipSize[16]   = { 1, 1, 1, 2, 2, 2, 1, 3, 2, 2, 1, 3, 3, 2, 2, 1 };

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.78"
+#define VERSION_ID "11.79"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
When a singular search shows a move besides the tt move fails high we assume it's safe to prune.

ELO   | 5.74 +- 4.14 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11072 W: 2358 L: 2175 D: 6539
http://chess.grantnet.us/viewTest/4087/

ELO   | 3.63 +- 2.80 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18496 W: 2996 L: 2803 D: 12697
http://chess.grantnet.us/viewTest/4091/