### PR TITLE
Add elo estimates to search steps

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.81"
+#define VERSION_ID "11.82"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
All tests @ 12.0+0.12s @ 1.275Mnps, Threads=1, Hash=8MB. Values correspond to the elo loss from the removal of the search step.

Beta Pruning

ELO   | -31.95 +- 3.21 (95%)
Games | N: 19150 W: 3219 L: 4975 D: 10956
http://chess.grantnet.us/viewTest/4324/

Null Move Pruning

ELO   | -93.08 +- 4.96 (95%)
Games | N: 9225 W: 1055 L: 3469 D: 4701
http://chess.grantnet.us/viewTest/4322/

Probcut Pruning

ELO   | -9.08 +- 2.59 (95%)
Games | N: 28736 W: 5621 L: 6372 D: 16743
http://chess.grantnet.us/viewTest/4323/

Quiet Move Pruning

ELO   | -175.08 +- 7.24 (95%)
Games | N: 5200 W: 276 L: 2695 D: 2229
http://chess.grantnet.us/viewTest/4328/

Futility Pruning

ELO   | -3.13 +- 1.97 (95%)
Games | N: 48443 W: 9639 L: 10075 D: 28729
http://chess.grantnet.us/viewTest/4340/

Futility Pruning No History

ELO   | -2.42 +- 1.99 (95%)
Games | N: 47423 W: 9476 L: 9806 D: 28141
http://chess.grantnet.us/viewTest/4341/

Late Move Pruning

ELO   | -76.88 +- 4.57 (95%)
Games | N: 9700 W: 1088 L: 3200 D: 5412
http://chess.grantnet.us/viewTest/4338/

Counter-move Pruning

ELO   | -8.10 +- 2.56 (95%)
Games | N: 28836 W: 5559 L: 6231 D: 17046
http://chess.grantnet.us/viewTest/4337/

Follow-up-move Pruning

ELO   | -1.60 +- 1.98 (95%)
Games | N: 48293 W: 9727 L: 9950 D: 28616
http://chess.grantnet.us/viewTest/4329/

SEE Pruning

ELO   | -41.54 +- 2.98 (95%)
Games | N: 22637 W: 3589 L: 6283 D: 12765
http://chess.grantnet.us/viewTest/4342/

Late Move Reduction

ELO   | -248.59 +- 10.48 (95%)
Games | N: 3501 W: 129 L: 2279 D: 1093
http://chess.grantnet.us/viewTest/4367/

Extensions

ELO   | -59.87 +- 4.36 (95%)
Games | N: 10895 W: 1522 L: 3381 D: 5992
http://chess.grantnet.us/viewTest/4368/

History

ELO   | -759.05 +- 57.40 (95%)
Games | N: 2000 W: 1 L: 1951 D: 48
http://chess.grantnet.us/viewTest/4369/

NO FUNCTIONAL CHANGE

BENCH : 8,004,737