### PR TITLE
Extra penalty for stacked passers

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -300,6 +300,11 @@ const int PassedEnemyDistance[8] = {
 
 const int PassedSafePromotionPath = S( -29,  37);
 
+const int PassedStacked[8] = {
+    S(   0,   0), S(   0,  -3), S(   0,  -6), S(   0, -10),
+    S(  -4, -12), S(  -8, -16), S(   0,   0), S(   0,   0),
+};
+
 /* Threat Evaluation Terms */
 
 const int ThreatWeakPawn             = S( -13, -26);
@@ -866,6 +871,12 @@ int evaluatePassed(EvalInfo *ei, Board *board, int colour) {
         flag = !(bitboard & (board->colours[THEM] | ei->attacked[THEM]));
         eval += flag * PassedSafePromotionPath;
         if (TRACE) T.PassedSafePromotionPath[US] += flag;
+
+        // Apply an extra penalty for stacked passers
+        if(forwardFileMasks(US, sq) & tempPawns) {
+            eval += PassedStacked[rank];
+            if (TRACE) T.PassedStacked[rank][US]++;
+        }
     }
 
     return eval;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -74,6 +74,7 @@ struct EvalTrace {
     int PassedFriendlyDistance[8][COLOUR_NB];
     int PassedEnemyDistance[8][COLOUR_NB];
     int PassedSafePromotionPath[COLOUR_NB];
+    int PassedStacked[8][COLOUR_NB];
     int ThreatWeakPawn[COLOUR_NB];
     int ThreatMinorAttackedByPawn[COLOUR_NB];
     int ThreatMinorAttackedByMinor[COLOUR_NB];

--- a/src/texel.c
+++ b/src/texel.c
@@ -80,6 +80,7 @@ extern const int PassedPawn[2][2][8];
 extern const int PassedFriendlyDistance[8];
 extern const int PassedEnemyDistance[8];
 extern const int PassedSafePromotionPath;
+extern const int PassedStacked[8];
 extern const int ThreatWeakPawn;
 extern const int ThreatMinorAttackedByPawn;
 extern const int ThreatMinorAttackedByMinor;

--- a/src/texel.h
+++ b/src/texel.h
@@ -25,7 +25,7 @@
 #define NPARTITIONS  (     64) // Total thread partitions
 #define KPRECISION   (     10) // Iterations for computing K
 #define REPORTING    (     25) // How often to report progress
-#define NTERMS       (      0) // Total terms in the Tuner (625)
+#define NTERMS       (      0) // Total terms in the Tuner (633)
 
 #define LEARNING     (    5.0) // Learning rate
 #define LRDROPRATE   (   1.25) // Cut LR by this each failure
@@ -74,6 +74,7 @@
 #define TunePassedFriendlyDistance      (0)
 #define TunePassedEnemyDistance         (0)
 #define TunePassedSafePromotionPath     (0)
+#define TunePassedStacked               (0)
 #define TuneThreatWeakPawn              (0)
 #define TuneThreatMinorAttackedByPawn   (0)
 #define TuneThreatMinorAttackedByMinor  (0)
@@ -266,6 +267,7 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_1(fname, PassedFriendlyDistance, 8, NORMAL);         \
     ENABLE_1(fname, PassedEnemyDistance, 8, NORMAL);            \
     ENABLE_0(fname, PassedSafePromotionPath, NORMAL);           \
+    ENABLE_1(fname, PassedStacked, 8, NORMAL);                  \
     ENABLE_0(fname, ThreatWeakPawn, NORMAL);                    \
     ENABLE_0(fname, ThreatMinorAttackedByPawn, NORMAL);         \
     ENABLE_0(fname, ThreatMinorAttackedByMinor, NORMAL);        \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.82"
+#define VERSION_ID "11.83"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Passed pawns get evaluation bonuses for the promotion threat they represent. However, a passer behind another one has its promotion potential greatly restricted by the extra tempi needed to move both pawns. It also prevents a friendly rook to protect the front passer from behind. This makes the base stacked pawn penalty insufficient.

This introduces a rank-based penalty to any additional passer in a file behind the frontmost one, compensating partially the passed pawn bonuses. The current values are educated guesses, with potential for improvement through tuning and tweaking.

ELO   | 6.95 +- 4.69 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8300 W: 1720 L: 1554 D: 5026
http://chess.grantnet.us/viewTest/4389/

ELO   | 3.55 +- 2.77 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19175 W: 3144 L: 2948 D: 13083
http://chess.grantnet.us/viewTest/4390/

BENCH : 8,068,571