### PR TITLE
Penalize mutually attacked squares that are poorly defended

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -75,6 +75,8 @@ struct EvalTrace {
     int PassedEnemyDistance[8][COLOUR_NB];
     int PassedSafePromotionPath[COLOUR_NB];
     int PassedStacked[8][COLOUR_NB];
+    int ThreatRestrictPiece[COLOUR_NB];
+    int ThreatRestrictEmpty[COLOUR_NB];
     int ThreatWeakPawn[COLOUR_NB];
     int ThreatMinorAttackedByPawn[COLOUR_NB];
     int ThreatMinorAttackedByMinor[COLOUR_NB];

--- a/src/texel.c
+++ b/src/texel.c
@@ -81,6 +81,8 @@ extern const int PassedFriendlyDistance[8];
 extern const int PassedEnemyDistance[8];
 extern const int PassedSafePromotionPath;
 extern const int PassedStacked[8];
+extern const int ThreatRestrictPiece;
+extern const int ThreatRestrictEmpty;
 extern const int ThreatWeakPawn;
 extern const int ThreatMinorAttackedByPawn;
 extern const int ThreatMinorAttackedByMinor;

--- a/src/texel.h
+++ b/src/texel.h
@@ -25,7 +25,7 @@
 #define NPARTITIONS  (     64) // Total thread partitions
 #define KPRECISION   (     10) // Iterations for computing K
 #define REPORTING    (     25) // How often to report progress
-#define NTERMS       (      0) // Total terms in the Tuner (633)
+#define NTERMS       (      0) // Total terms in the Tuner (635)
 
 #define LEARNING     (    5.0) // Learning rate
 #define LRDROPRATE   (   1.25) // Cut LR by this each failure
@@ -75,6 +75,8 @@
 #define TunePassedEnemyDistance         (0)
 #define TunePassedSafePromotionPath     (0)
 #define TunePassedStacked               (0)
+#define TuneThreatRestrictPiece         (0)
+#define TuneThreatRestrictEmpty         (0)
 #define TuneThreatWeakPawn              (0)
 #define TuneThreatMinorAttackedByPawn   (0)
 #define TuneThreatMinorAttackedByMinor  (0)
@@ -268,6 +270,8 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_1(fname, PassedEnemyDistance, 8, NORMAL);            \
     ENABLE_0(fname, PassedSafePromotionPath, NORMAL);           \
     ENABLE_1(fname, PassedStacked, 8, NORMAL);                  \
+    ENABLE_0(fname, ThreatRestrictPiece, NORMAL);               \
+    ENABLE_0(fname, ThreatRestrictEmpty, NORMAL);               \
     ENABLE_0(fname, ThreatWeakPawn, NORMAL);                    \
     ENABLE_0(fname, ThreatMinorAttackedByPawn, NORMAL);         \
     ENABLE_0(fname, ThreatMinorAttackedByMinor, NORMAL);        \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.84"
+#define VERSION_ID "11.85"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Idea from Stockfish.

ELO   | 3.09 +- 2.46 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30336 W: 6175 L: 5905 D: 18256
http://chess.grantnet.us/viewTest/4410/

ELO   | 4.70 +- 3.36 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12498 W: 1996 L: 1827 D: 8675
http://chess.grantnet.us/viewTest/4411/