### PR TITLE
Tune mobility restriction values

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -301,14 +301,14 @@ const int PassedEnemyDistance[8] = {
 const int PassedSafePromotionPath = S( -29,  37);
 
 const int PassedStacked[RANK_NB] = {
-    S(   0,   0), S(   0,  -3), S(   0,  -6), S(   0, -10),
+    S(   0,   0), S(   0,   0), S(   0,  -6), S(   0, -10),
     S(  -4, -12), S(  -8, -16), S(   0,   0), S(   0,   0),
 };
 
 /* Threat Evaluation Terms */
 
-const int ThreatRestrictPiece        = S(  -1,  -1);
-const int ThreatRestrictEmpty        = S(  -3,  -1);
+const int ThreatRestrictPiece        = S(  -3,  -1);
+const int ThreatRestrictEmpty        = S(  -4,  -2);
 const int ThreatWeakPawn             = S( -13, -26);
 const int ThreatMinorAttackedByPawn  = S( -51, -53);
 const int ThreatMinorAttackedByMinor = S( -26, -36);

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.85"
+#define VERSION_ID "11.86"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO   | 5.00 +- 4.09 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10974 W: 2258 L: 2100 D: 6616
http://chess.grantnet.us/viewTest/4414/

ELO   | 3.62 +- 3.09 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 14862 W: 2361 L: 2206 D: 10295
http://chess.grantnet.us/viewTest/4418/

BENCH : 7,752,370