### PR TITLE
Penalize knights that are far from both kings

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -55,14 +55,14 @@ const int PawnPSQT32[32] = {
 };
 
 const int KnightPSQT32[32] = {
-    S( -50, -26), S(  -8, -40), S( -16, -29), S(  -1, -19),
-    S(  -6, -22), S(   3, -13), S(   1, -31), S(  11, -20),
-    S(   3, -25), S(  20, -25), S(  14, -18), S(  25,  -5),
-    S(  15,   4), S(  23,   6), S(  29,  17), S(  30,  22),
-    S(  24,  17), S(  26,  11), S(  39,  26), S(  30,  39),
-    S( -14,  15), S(   6,  13), S(  32,  27), S(  33,  29),
-    S(   7, -11), S(  -5,   2), S(  36, -20), S(  43,   0),
-    S(-168, -17), S( -81,  -2), S(-110,  19), S( -30,   1),
+    S( -49, -26), S(  -8, -34), S( -13, -27), S(   1, -17), 
+    S(  -2, -21), S(   4, -12), S(   4, -29), S(  10, -18), 
+    S(   9, -25), S(  22, -24), S(  14, -18), S(  23,  -6), 
+    S(  19,   4), S(  23,   6), S(  31,  14), S(  30,  21), 
+    S(  25,  17), S(  28,  10), S(  39,  24), S(  31,  36), 
+    S( -14,  15), S(   6,  12), S(  31,  25), S(  30,  27), 
+    S(   8, -11), S(  -7,   1), S(  33, -21), S(  42,  -1), 
+    S(-170, -18), S( -81,  -2), S(-110,  19), S( -30,   0), 
 };
 
 const int BishopPSQT32[32] = {
@@ -143,6 +143,10 @@ const int KnightOutpost[2][2] = {
 };
 
 const int KnightBehindPawn = S(   4,  19);
+
+const int KnightInSiberia[4] = {
+    S(  -7,   0), S(  -9,  -4), S( -17,  -3), S( -17,  -1), 
+};
 
 const int KnightMobility[9] = {
     S( -74,-104), S( -31, -96), S( -16, -41), S(  -5, -16),
@@ -502,7 +506,7 @@ int evaluateKnights(EvalInfo *ei, Board *board, int colour) {
 
     const int US = colour, THEM = !colour;
 
-    int sq, outside, defended, count, eval = 0;
+    int sq, outside, kingDistance, defended, count, eval = 0;
     uint64_t attacks;
 
     uint64_t enemyPawns  = board->pieces[PAWN  ] & board->colours[THEM];
@@ -538,6 +542,13 @@ int evaluateKnights(EvalInfo *ei, Board *board, int colour) {
         if (testBit(pawnAdvance(board->pieces[PAWN], 0ull, THEM), sq)) {
             eval += KnightBehindPawn;
             if (TRACE) T.KnightBehindPawn[US]++;
+        }
+
+        // Apply a penalty if the knight is far from both kings
+        kingDistance = MIN(distanceBetween(sq, ei->kingSquare[THEM]), distanceBetween(sq, ei->kingSquare[US]));
+        if (kingDistance >= 4) {
+            eval += KnightInSiberia[kingDistance - 4];
+            if (TRACE) T.KnightInSiberia[kingDistance - 4][US]++;
         }
 
         // Apply a bonus (or penalty) based on the mobility of the knight

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -56,6 +56,7 @@ struct EvalTrace {
     int PawnConnected32[32][COLOUR_NB];
     int KnightOutpost[2][2][COLOUR_NB];
     int KnightBehindPawn[COLOUR_NB];
+    int KnightInSiberia[4][COLOUR_NB];
     int KnightMobility[9][COLOUR_NB];
     int BishopPair[COLOUR_NB];
     int BishopRammedPawns[COLOUR_NB];

--- a/src/texel.c
+++ b/src/texel.c
@@ -62,6 +62,7 @@ extern const int PawnBackwards[2];
 extern const int PawnConnected32[32];
 extern const int KnightOutpost[2][2];
 extern const int KnightBehindPawn;
+extern const int KnightInSiberia[4];
 extern const int KnightMobility[9];
 extern const int BishopPair;
 extern const int BishopRammedPawns;

--- a/src/texel.h
+++ b/src/texel.h
@@ -25,11 +25,11 @@
 #define NPARTITIONS  (     64) // Total thread partitions
 #define KPRECISION   (     10) // Iterations for computing K
 #define REPORTING    (     25) // How often to report progress
-#define NTERMS       (      0) // Total terms in the Tuner (636)
+#define NTERMS       (      0) // Total terms in the Tuner (640)
 
 #define LEARNING     (    5.0) // Learning rate
 #define LRDROPRATE   (   1.25) // Cut LR by this each failure
-#define BATCHSIZE    (7400000) // FENs per mini-batch
+#define BATCHSIZE    (  16384) // FENs per mini-batch
 #define NPOSITIONS   (7400000) // Total FENS in the book
 
 #define STATICWEIGHT (   0.50) // Weight of the Static Evaluation
@@ -56,6 +56,7 @@
 #define TunePawnConnected32             (0)
 #define TuneKnightOutpost               (0)
 #define TuneKnightBehindPawn            (0)
+#define TuneKnightInSiberia             (0)
 #define TuneKnightMobility              (0)
 #define TuneBishopPair                  (0)
 #define TuneBishopRammedPawns           (0)
@@ -252,6 +253,7 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_1(fname, PawnConnected32, 32, NORMAL);               \
     ENABLE_2(fname, KnightOutpost, 2, 2, NORMAL);               \
     ENABLE_0(fname, KnightBehindPawn, NORMAL);                  \
+    ENABLE_1(fname, KnightInSiberia, 4, NORMAL);                \
     ENABLE_1(fname, KnightMobility, 9, NORMAL);                 \
     ENABLE_0(fname, BishopPair, NORMAL);                        \
     ENABLE_0(fname, BishopRammedPawns, NORMAL);                 \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.87"
+#define VERSION_ID "11.88"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Such knights are rarely effective attackers or defenders, and frequently require multiple moves to be made more active. This was thought as a middlegame penalty, because in endgames direct king attacks are less dangerous and maneuvering to block or support passed pawns becomes more important. The tuner's suggested values supported this.

The knight PSQT has been retuned alongside, with a noticeable increase in edge values on the home rank and on the A/H files.

ELO   | 8.00 +- 5.18 (95%)
SPRT  | 12.0+0.12s @ 1.275mnps Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7124 W: 1553 L: 1389 D: 4182
http://chess.grantnet.us/viewTest/4443/

ELO   | 4.55 +- 3.32 (95%)
SPRT  | 60.0+0.6s @ 1.275mnps Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13448 W: 2239 L: 2063 D: 9146
http://chess.grantnet.us/viewTest/4444/

BENCH : 8,846,177