### PR TITLE
Increase the SEE pruning depth from 8 to 9

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -78,7 +78,7 @@ static const int LateMovePruningCounts[2][9] = {
     {  0,  5,  7, 11, 17, 26, 36, 48, 63},
 };
 
-static const int SEEPruningDepth = 8;
+static const int SEEPruningDepth = 9;
 static const int SEEQuietMargin = -80;
 static const int SEENoisyMargin = -18;
 static const int SEEPieceValues[] = {

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.88"
+#define VERSION_ID "11.89"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO   | 2.56 +- 1.99 (95%)
SPRT  | 12.0+0.12s @ 1.275Mnps Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 46725 W: 9485 L: 9141 D: 28099
http://chess.grantnet.us/viewTest/4450/

ELO   | 2.08 +- 1.61 (95%)
SPRT  | 60.0+0.6s @ 1.275MnpsThreads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 54369 W: 8492 L: 8167 D: 37710
http://chess.grantnet.us/viewTest/4453/

BENCH : 8,102,906