### PR TITLE
Make the backward pawn penalty different by rank

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -44,13 +44,13 @@ const int KingValue   = S(   0,   0);
 /* Piece Square Evaluation Terms */
 
 const int PawnPSQT32[32] = {
-    S(   0,   0), S(   0,   0), S(   0,   0), S(   0,   0),
-    S( -19,   9), S(   6,   4), S( -11,   7), S(  -6,  -1),
-    S( -21,   4), S( -11,   3), S(  -8,  -5), S(  -2, -13),
-    S( -16,  12), S( -10,  11), S(  14, -13), S(  12, -24),
-    S(  -4,  16), S(   4,  11), S(   0,  -2), S(  14, -21),
-    S(  -4,  32), S(   1,  30), S(  10,  19), S(  38,  -8),
-    S( -17, -40), S( -65,  -9), S(   3, -23), S(  40, -37),
+    S(   0,   0), S(   0,   0), S(   0,   0), S(   0,   0), 
+    S( -20,   5), S(   2,   1), S( -13,   4), S(  -8,  -2), 
+    S( -23,   2), S( -16,   2), S( -10,  -7), S(  -5, -15), 
+    S( -18,   8), S( -14,   8), S(  10, -14), S(   8, -27), 
+    S(  -9,  10), S(  -5,   6), S(  -7,  -8), S(   2, -24), 
+    S(  -8,  23), S(  -5,  21), S(   2,  10), S(  29, -17), 
+    S( -19, -48), S( -67, -15), S(   1, -29), S(  38, -43), 
     S(   0,   0), S(   0,   0), S(   0,   0), S(   0,   0),
 };
 
@@ -122,7 +122,12 @@ const int PawnIsolated = S(  -7, -11);
 
 const int PawnStacked[2] = { S(  -9, -14), S(  -9,  -9) };
 
-const int PawnBackwards[2] = { S(   7,   0), S(  -7, -19) };
+const int PawnBackwards[2][8] = {
+   {S(   0,   0), S(   3,  -7), S(   9,  -5), S(   7,  -9),
+    S(   9,  -9), S(   0,   0), S(   0,   0), S(   0,   0)},
+   {S(   0,   0), S( -10, -30), S(  -5, -26), S(   2, -26),
+    S(   5, -23), S(   0,   0), S(   0,   0), S(   0,   0)},
+};
 
 const int PawnConnected32[32] = {
     S(   0,   0), S(   0,   0), S(   0,   0), S(   0,   0),
@@ -485,8 +490,8 @@ int evaluatePawns(EvalInfo *ei, Board *board, int colour) {
         // backwards at the same time. We don't give backward pawns a connected bonus
         if (neighbors && pushThreats && !backup) {
             flag = !(Files[fileOf(sq)] & enemyPawns);
-            pkeval += PawnBackwards[flag];
-            if (TRACE) T.PawnBackwards[flag][US]++;
+            pkeval += PawnBackwards[flag][relativeRankOf(US, sq)];
+            if (TRACE) T.PawnBackwards[flag][relativeRankOf(US, sq)][US]++;
         }
 
         // Apply a bonus if the pawn is connected and not backwards. We consider a

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -52,7 +52,7 @@ struct EvalTrace {
     int PawnCandidatePasser[2][8][COLOUR_NB];
     int PawnIsolated[COLOUR_NB];
     int PawnStacked[2][COLOUR_NB];
-    int PawnBackwards[2][COLOUR_NB];
+    int PawnBackwards[2][8][COLOUR_NB];
     int PawnConnected32[32][COLOUR_NB];
     int KnightOutpost[2][2][COLOUR_NB];
     int KnightBehindPawn[COLOUR_NB];

--- a/src/texel.c
+++ b/src/texel.c
@@ -58,7 +58,7 @@ extern const int KingPSQT32[32];
 extern const int PawnCandidatePasser[2][8];
 extern const int PawnIsolated;
 extern const int PawnStacked[2];
-extern const int PawnBackwards[2];
+extern const int PawnBackwards[2][8];
 extern const int PawnConnected32[32];
 extern const int KnightOutpost[2][2];
 extern const int KnightBehindPawn;

--- a/src/texel.h
+++ b/src/texel.h
@@ -25,7 +25,7 @@
 #define NPARTITIONS  (     64) // Total thread partitions
 #define KPRECISION   (     10) // Iterations for computing K
 #define REPORTING    (     25) // How often to report progress
-#define NTERMS       (      0) // Total terms in the Tuner (640)
+#define NTERMS       (      0) // Total terms in the Tuner (654)
 
 #define LEARNING     (    5.0) // Learning rate
 #define LRDROPRATE   (   1.25) // Cut LR by this each failure
@@ -249,7 +249,7 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_2(fname, PawnCandidatePasser, 2, 8, NORMAL);         \
     ENABLE_0(fname, PawnIsolated, NORMAL);                      \
     ENABLE_1(fname, PawnStacked, 2, NORMAL);                    \
-    ENABLE_1(fname, PawnBackwards, 2, NORMAL);                  \
+    ENABLE_2(fname, PawnBackwards, 2, 8, NORMAL);               \
     ENABLE_1(fname, PawnConnected32, 32, NORMAL);               \
     ENABLE_2(fname, KnightOutpost, 2, 2, NORMAL);               \
     ENABLE_0(fname, KnightBehindPawn, NORMAL);                  \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.89"
+#define VERSION_ID "11.90"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
A backward pawn is a bigger handicap when it's closer to its starting rank.

Also retune the pawn PSQT alongside.

ELO   | 3.77 +- 3.01 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20734 W: 4314 L: 4089 D: 12331
http://chess.grantnet.us/viewTest/4466/

ELO   | 2.33 +- 1.84 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 42345 W: 6734 L: 6450 D: 29161
http://chess.grantnet.us/viewTest/4470/

BENCH : 7,971,790