### PR TITLE
Prefetch hash entries

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -212,6 +212,9 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
     if (depth <= 0 && !board->kingAttackers)
         return qsearch(thread, pv, alpha, beta, height);
 
+    // Prefetch TT as early as reasonable
+    prefetchTTEntry(board->hash);
+
     // Ensure a fresh PV
     pv->length = 0;
 
@@ -546,6 +549,9 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
         }
     }
 
+    // Prefetch TT for store
+    prefetchTTEntry(board->hash);
+
     // Step 17. Stalemate and Checkmate detection. If no moves were found to
     // be legal (search makes sure to play at least one legal move, if any),
     // then we are either mated or stalemated, which we can tell by the inCheck
@@ -577,6 +583,9 @@ int qsearch(Thread *thread, PVariation *pv, int alpha, int beta, int height) {
     uint16_t move, ttMove = NONE_MOVE;
     MovePicker movePicker;
     PVariation lpv;
+
+    // Prefetch TT as early as reasonable
+    prefetchTTEntry(board->hash);
 
     // Ensure a fresh PV
     pv->length = 0;

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -106,6 +106,12 @@ int valueToTT(int value, int height) {
          : value <= MATED_IN_MAX ? value - height : value;
 }
 
+void prefetchTTEntry(uint64_t hash) {
+
+    TTBucket *bucket = &Table.buckets[hash & Table.hashMask];
+    __builtin_prefetch(bucket);
+}
+
 int getTTEntry(uint64_t hash, uint16_t *move, int *value, int *eval, int *depth, int *bound) {
 
     const uint16_t hash16 = hash >> 48;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -75,6 +75,7 @@ void clearTT();
 int hashfullTT();
 int valueFromTT(int value, int height);
 int valueToTT(int value, int height);
+void prefetchTTEntry(uint64_t hash);
 int getTTEntry(uint64_t hash, uint16_t *move, int *value, int *eval, int *depth, int *bound);
 void storeTTEntry(uint64_t hash, uint16_t move, int value, int eval, int depth, int bound);
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.91"
+#define VERSION_ID "11.92"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
<pre>ELO   | 6.27 +- 4.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10027 W: 2202 L: 2021 D: 5804
http://chess.grantnet.us/viewTest/4578/

ELO   | 4.24 +- 3.26 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16700 W: 3308 L: 3104 D: 10288
http://chess.grantnet.us/viewTest/4580/

NO FUNCTIONAL CHANGE

BENCH : 7,681,536</pre>

The only diff between the commit used in testing is the VERSION_ID bump in uci.h.

Thanks to @TerjeKir for rebasing my original prefetch patch and fixing a small whitespace issue, and @Alayan-stk-2 for further pointers on preparing the PR.