### PR TITLE
Introduce contempt

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -359,7 +359,7 @@ const int Tempo = 20;
 
 #undef S
 
-int evaluateBoard(Board *board, PKTable *pktable) {
+int evaluateBoard(Board *board, PKTable *pktable, int contempt) {
 
     EvalInfo ei;
     int phase, factor, eval, pkeval;
@@ -369,6 +369,7 @@ int evaluateBoard(Board *board, PKTable *pktable) {
     eval   = evaluatePieces(&ei, board);
     pkeval = ei.pkeval[WHITE] - ei.pkeval[BLACK];
     eval  += pkeval + board->psqtmat;
+    eval  += contempt;
     eval  += evaluateClosedness(&ei, board);
     eval  += evaluateComplexity(&ei, board, eval);
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -119,7 +119,7 @@ struct EvalInfo {
     PKEntry *pkentry;
 };
 
-int evaluateBoard(Board *board, PKTable *pktable);
+int evaluateBoard(Board *board, PKTable *pktable, int contempt);
 int evaluatePieces(EvalInfo *ei, Board *board);
 int evaluatePawns(EvalInfo *ei, Board *board, int colour);
 int evaluateKnights(EvalInfo *ei, Board *board, int colour);

--- a/src/thread.c
+++ b/src/thread.c
@@ -20,11 +20,16 @@
 #include <string.h>
 
 #include "board.h"
+#include "evaluate.h"
 #include "history.h"
 #include "search.h"
 #include "thread.h"
 #include "transposition.h"
 #include "types.h"
+
+// Default contempt values, UCI options can set them to other values
+int ContemptDrawPenalty = 12;
+int ContemptComplexity  = 12;
 
 Thread* createThreadPool(int nthreads) {
 
@@ -80,6 +85,11 @@ void newSearchThreadPool(Thread *threads, Board *board, Limits *limits, SearchIn
         threads[i].info = info;
         threads[i].nodes = threads[i].tbhits = 0ull;
         memcpy(&threads[i].board, board, sizeof(Board));
+
+        // Build contempt score for the side to move using UCI settings
+        threads[i].contempt = board->turn == WHITE
+                            ? MakeScore( ContemptDrawPenalty + ContemptComplexity,  ContemptDrawPenalty)
+                            : MakeScore(-ContemptDrawPenalty - ContemptComplexity, -ContemptDrawPenalty);
     }
 }
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -43,6 +43,7 @@ struct Thread {
     uint16_t bestMoves[MAX_MOVES];
     uint16_t ponderMoves[MAX_MOVES];
 
+    int contempt;
     int depth, seldepth;
     uint64_t nodes, tbhits;
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -40,6 +40,8 @@
 #include "uci.h"
 #include "zobrist.h"
 
+extern int ContemptDrawPenalty;   // Defined by Thread.c
+extern int ContemptComplexity;    // Defined by Thread.c
 extern int MoveOverhead;          // Defined by Time.c
 extern unsigned TB_PROBE_DEPTH;   // Defined by Syzygy.c
 extern volatile int ABORT_SIGNAL; // Defined by Search.c
@@ -85,6 +87,8 @@ int main(int argc, char **argv) {
             printf("option name Hash type spin default 16 min 1 max 65536\n");
             printf("option name Threads type spin default 1 min 1 max 2048\n");
             printf("option name MultiPV type spin default 1 min 1 max 256\n");
+            printf("option name ContemptDrawPenalty type spin default 0 min -300 max 300\n");
+            printf("option name ContemptComplexity type spin default 0 min -100 max 100\n");
             printf("option name MoveOverhead type spin default 100 min 0 max 10000\n");
             printf("option name SyzygyPath type string default <empty>\n");
             printf("option name SyzygyProbeDepth type spin default 0 min 0 max 127\n");
@@ -220,13 +224,15 @@ void *uciGo(void *cargo) {
 void uciSetOption(char *str, Thread **threads, int *multiPV, int *chess960) {
 
     // Handle setting UCI options in Ethereal. Options include:
-    //  Hash             : Size of the Transposition Table in Megabyes
-    //  Threads          : Number of search threads to use
-    //  MultiPV          : Number of search lines to report per iteration
-    //  MoveOverhead     : Overhead on time allocation to avoid time losses
-    //  SyzygyPath       : Path to Syzygy Tablebases
-    //  SyzygyProbeDepth : Minimal Depth to probe the highest cardinality Tablebase
-    //  UCI_Chess960     : Set when playing FRC, but not required in order to work
+    //  Hash                : Size of the Transposition Table in Megabyes
+    //  Threads             : Number of search threads to use
+    //  MultiPV             : Number of search lines to report per iteration
+    //  ContemptDrawPenalty : Evaluation bonus in internal units to avoid forced draws
+    //  ContemptComplexity  : Evaluation bonus for keeping a position with more non-pawn material
+    //  MoveOverhead        : Overhead on time allocation to avoid time losses
+    //  SyzygyPath          : Path to Syzygy Tablebases
+    //  SyzygyProbeDepth    : Minimal Depth to probe the highest cardinality Tablebase
+    //  UCI_Chess960        : Set when playing FRC, but not required in order to work
 
     if (strStartsWith(str, "setoption name Hash value ")) {
         int megabytes = atoi(str + strlen("setoption name Hash value "));
@@ -242,6 +248,16 @@ void uciSetOption(char *str, Thread **threads, int *multiPV, int *chess960) {
     if (strStartsWith(str, "setoption name MultiPV value ")) {
         *multiPV = atoi(str + strlen("setoption name MultiPV value "));
         printf("info string set MultiPV to %d\n", *multiPV);
+    }
+
+    if (strStartsWith(str, "setoption name ContemptDrawPenalty value ")){
+        ContemptDrawPenalty = atoi(str + strlen("setoption name ContemptDrawPenalty value "));
+        printf("info string set ContemptDrawPenalty to %d\n", ContemptDrawPenalty);
+    }
+
+    if (strStartsWith(str, "setoption name ContemptComplexity value ")){
+        ContemptComplexity = atoi(str + strlen("setoption name ContemptComplexity value "));
+        printf("info string set ContemptComplexity to %d\n", ContemptComplexity);
     }
 
     if (strStartsWith(str, "setoption name MoveOverhead value ")) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.92"
+#define VERSION_ID "11.93"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Contempt is a method which adjusts the eval of positions depending on the side to move at the root of the search tree. In Stockfish, contempt mixes two ideas : a bonus to the side to move to prefer slightly negative evaluations to drawn terminal nodes, and an incentive to not exchange non-pawn material in order to keep the position more complicated.

Here, we separate these two concepts.

The draw penalty makes Ethereal less likely to accept three-folds when declining only leads to a minor disadvantage. It also helps to explore more alternative lines to those with forced draws.

The complexity bonus make use of tapered eval to prefer positions with more non-pawn material on the board. These positions are usually more complex, and thus more likely to allow outplaying a weaker opponent - at the cost of being more likely to make mistakes.

Separating these two offers more flexibility. For example, a negative complexity contempt coupled with a positive draw penalty will incentivize piece exchanges yet discourage accepting a draw too easily. The ideal balance of strength and decisive results is also unlikely to have both values equal in all situations.

Both of these forms of contempt help to increase the proportion of decisive games. The STC statistics collected in testing show it clearly:

DP + Comp | DP2 + Comp2 | Draw rate | Test link
 0 +  0   |   0 +  0    |     60.8% | http://chess.grantnet.us/viewTest/4511/
 0 + 12   |   0 +  0    |     58.1% | http://chess.grantnet.us/viewTest/4564
12 +  0   |   0 +  0    |     57.6% | http://chess.grantnet.us/viewTest/4565
10 +  6   |   0 +  0    |     57.5% | http://chess.grantnet.us/viewTest/4567
12 + 12   |   0 +  0    |     55.5% | http://chess.grantnet.us/viewTest/4571
12 + 12   |  12 + 12    |     51.7% | http://chess.grantnet.us/viewTest/4601/

The base code with (0, 0) parameters passed non-regression:

ELO   | 0.26 +- 2.05 (95%)
SPRT  | 3+0.03s Threads=1 Hash=4MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 56624 W: 14656 L: 14613 D: 27355
http://chess.grantnet.us/viewTest/4600/

Contempt (12, 12) passed non-regression against (0, 0):

ELO   | 3.06 +- 2.59 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-2.00, 0.00]
Games | N: 30565 W: 6932 L: 6663 D: 16970
http://chess.grantnet.us/viewTest/4571

ELO   | 1.41 +- 2.43 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 27099 W: 4743 L: 4633 D: 17723
http://chess.grantnet.us/viewTest/4583

BENCH : 7,692,735