### PR TITLE
Scale down the eval advantage (if any) for a lone queen against multiple minors/rooks

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -32,6 +32,7 @@ enum {
     SCALE_OCB_BISHOPS_ONLY =  64,
     SCALE_OCB_ONE_KNIGHT   = 106,
     SCALE_OCB_ONE_ROOK     =  96,
+    SCALE_LONE_QUEEN       =  88,
     SCALE_DRAW             =   0,
     SCALE_NORMAL           = 128,
 };

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.93"
+#define VERSION_ID "11.94"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
A lone queen can not take any enemy piece that is protected, and pawns have a very reduced mobility to assist in making threats. This means that in endgames, two or three minors and rooks that are well coordinated can make the queen's threats empty.

This patch doesn't change evaluation when static already favors the side with the pieces (typically, rook and two minors), but it is especially useful to moderate the often illusory material advantage of a lone queen against a rook and a minor.

ELO   | 3.52 +- 2.83 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 27909 W: 6863 L: 6580 D: 14466
http://chess.grantnet.us/viewTest/4622/

ELO   | 3.33 +- 2.68 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 25111 W: 5030 L: 4789 D: 15292
http://chess.grantnet.us/viewTest/4623/

BENCH : 8,376,081