### PR TITLE
Advise the kernel to use transparent huge pages for hash (Linux)

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -29,10 +29,9 @@
 #include "types.h"
 
 TTable Table; // Global Transposition Table
+static const uint64_t MB = 1ull << 20;
 
 void initTT(uint64_t megabytes) {
-
-    const uint64_t MB = 1ull << 20;
 
     // Cleanup memory when resizing the table
     if (Table.hashMask) free(Table.buckets);
@@ -59,6 +58,10 @@ void initTT(uint64_t megabytes) {
     Table.hashMask = (1ull << keySize) - 1u;
 
     clearTT(); // Clear the table and load everything into the cache
+}
+
+int hashSizeMBTT() {
+    return ((Table.hashMask + 1) * sizeof(TTBucket)) / MB;
 }
 
 void updateTT() {

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -21,6 +21,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(__linux__)
+    #include <sys/mman.h>
+#endif
+
 #include "transposition.h"
 #include "types.h"
 
@@ -28,25 +32,31 @@ TTable Table; // Global Transposition Table
 
 void initTT(uint64_t megabytes) {
 
-    uint64_t keySize = 16ull;
+    const uint64_t MB = 1ull << 20;
 
     // Cleanup memory when resizing the table
     if (Table.hashMask) free(Table.buckets);
 
-    // The smallest TT size we allow is 1MB, which matches up with
-    // a TT using a 15 bit lookup key. We start the key at 16, because
-    // while adjusting the given size to the nearest power of two less
-    // than or equal to the size, we end with a decrement to the key
-    // size. The formula works under the assumption that a TTBucket is
-    // exactly 32 bytes. We assure this in order to get good caching
+    // Use a default keysize of 16 bits, which should be equal to
+    // the smallest possible hash table size, which is 2 megabytes
+    assert((1ull << 16ull) * sizeof(TTBucket) == 2 * MB);
+    uint64_t keySize = 16ull;
 
-    for (;1ull << (keySize + 5) <= megabytes << 20 ; keySize++);
-    assert(sizeof(TTBucket) == 32);
-    keySize = keySize - 1;
+    // Find the largest keysize that is still within our given megabytes
+    while ((1ull << keySize) * sizeof(TTBucket) <= megabytes * MB / 2) keySize++;
+    assert((1ull << keySize) * sizeof(TTBucket) <= megabytes * MB);
 
-    // Allocate the TTBuckets and save the lookup mask
+#if defined(__linux__)
+    // On Linux systems we align on 2MB boundaries and request Huge Pages
+    Table.buckets = aligned_alloc(2 * MB, (1ull << keySize) * sizeof(TTBucket));
+    madvise(Table.buckets, (1ull << keySize) * sizeof(TTBucket), MADV_HUGEPAGE);
+#else
+    // Otherwise, we simply allocate as usual and make no requests
+    Table.buckets = malloc((1ull << keySize) * sizeof(TTBucket));
+#endif
+
+    // Save the lookup mask
     Table.hashMask = (1ull << keySize) - 1u;
-    Table.buckets  = malloc(sizeof(TTBucket) * (1ull << keySize));
 
     clearTT(); // Clear the table and load everything into the cache
 }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -70,6 +70,7 @@ struct PKTable {
 };
 
 void initTT(uint64_t megabytes);
+int hashSizeMBTT();
 void updateTT();
 void clearTT();
 int hashfullTT();

--- a/src/uci.c
+++ b/src/uci.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
         if (strEquals(str, "uci")) {
             printf("id name Ethereal " ETHEREAL_VERSION "\n");
             printf("id author Andrew Grant, Alayan & Laldon\n");
-            printf("option name Hash type spin default 16 min 1 max 65536\n");
+            printf("option name Hash type spin default 16 min 2 max 65536\n");
             printf("option name Threads type spin default 1 min 1 max 2048\n");
             printf("option name MultiPV type spin default 1 min 1 max 256\n");
             printf("option name ContemptDrawPenalty type spin default 12 min -300 max 300\n");

--- a/src/uci.c
+++ b/src/uci.c
@@ -236,7 +236,7 @@ void uciSetOption(char *str, Thread **threads, int *multiPV, int *chess960) {
 
     if (strStartsWith(str, "setoption name Hash value ")) {
         int megabytes = atoi(str + strlen("setoption name Hash value "));
-        initTT(megabytes); printf("info string set Hash to %dMB\n", megabytes);
+        initTT(megabytes); printf("info string set Hash to %dMB\n", hashSizeMBTT());
     }
 
     if (strStartsWith(str, "setoption name Threads value ")) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.98"
+#define VERSION_ID "11.99"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
On Linux, align the transposition table allocation by 2M to make it
large page friendly and advise the kernel to use transparent huge
pages.

Depending on the system configuration, hash size, number of threads
and CPUs, and other factors, the performance improvement can be
expected to be anywhere from 0% to 30%, although the performance
should not almost ever degrade.(*) Generally, bigger hashes and more
threads should result in bigger advantage.

The transparent huge page settings are in files:
- /sys/kernel/mm/transparent_hugepage/enabled
- /sys/kernel/mm/transparent_hugepage/defrag

On my box (core-i7 8700k), when both settings are always/always (most
aggressive), the performance improvement on my box is 1.2% on default
bench and 1.4% on "bench 14 1 2048". In this setting, the performance
improvement is purely due to alignment.

When the the settings are on madvise/madvise (conservative), the
performance improvement numbers are 2.1% and 9.6%. This time the
performance improvement is due to the use of large (2M) memory pages
rather than the small (4k) memory pages.

The perf increase numbers were measured with 'perf'.

(*) On very small hash sizes and transparent huge pages in "always"
settings, there may be a slight perf degradation due to 2M alignment
requiring one extra page from the "sbrk"-based main arena.

<pre>ELO   | 0.21 +- 1.93 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.94 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 61475 W: 15294 L: 15256 D: 30925</pre>
http://chess.grantnet.us/viewTest/4634/

<pre>ELO   | 4.16 +- 4.43 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 12279 W: 3270 L: 3123 D: 5886</pre>
http://chess.grantnet.us/viewTest/4641/

NO FUNCTIONAL CHANGE.

BENCH 8,376,081

Thanks again to @Alayan-stk-2 and @TerjeKir for helping me with this change.