### PR TITLE
Resolve fail highs with shallower searches

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.95"
+#define VERSION_ID "11.96"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Spend less time resolving fail highs by progressively reducing the searched depth for each successive fail. Resets upon failing low.

Inspired by Stockfish.

ELO   | 10.62 +- 6.46 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5399 W: 1395 L: 1230 D: 2774
http://chess.grantnet.us/viewTest/4715/

ELO   | 4.76 +- 3.57 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13785 W: 2720 L: 2531 D: 8534
http://chess.grantnet.us/viewTest/4716/

BENCH: 7536246