### PR TITLE
Exclude attacks on double-pawn-protected squares for king safety

### DIFF
--- a/src/attacks.c
+++ b/src/attacks.c
@@ -178,6 +178,11 @@ uint64_t pawnAttackSpan(uint64_t pawns, uint64_t targets, int colour) {
         | pawnRightAttacks(pawns, targets, colour);
 }
 
+uint64_t pawnAttackDouble(uint64_t pawns, uint64_t targets, int colour) {
+    return pawnLeftAttacks(pawns, targets, colour)
+        & pawnRightAttacks(pawns, targets, colour);
+}
+
 uint64_t pawnAdvance(uint64_t pawns, uint64_t occupied, int colour) {
     return ~occupied & (colour == WHITE ? (pawns << 8) : (pawns >> 8));
 }

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -41,6 +41,7 @@ uint64_t kingAttacks(int sq);
 uint64_t pawnLeftAttacks(uint64_t pawns, uint64_t targets, int colour);
 uint64_t pawnRightAttacks(uint64_t pawns, uint64_t targets, int colour);
 uint64_t pawnAttackSpan(uint64_t pawns, uint64_t targets, int colour);
+uint64_t pawnAttackDouble(uint64_t pawns, uint64_t targets, int colour);
 uint64_t pawnAdvance(uint64_t pawns, uint64_t occupied, int colour);
 uint64_t pawnEnpassCaptures(uint64_t pawns, int epsq, int colour);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -564,7 +564,7 @@ int evaluateKnights(EvalInfo *ei, Board *board, int colour) {
         if (TRACE) T.KnightMobility[count][US]++;
 
         // Update King Safety calculations
-        if ((attacks &= ei->kingAreas[THEM])) {
+        if ((attacks &= ei->kingAreas[THEM] & ~ei->pawnAttacksBy2[THEM])) {
             ei->kingAttacksCount[US] += popcount(attacks);
             ei->kingAttackersCount[US] += 1;
             ei->kingAttackersWeight[US] += KSAttackWeight[KNIGHT];
@@ -641,7 +641,7 @@ int evaluateBishops(EvalInfo *ei, Board *board, int colour) {
         if (TRACE) T.BishopMobility[count][US]++;
 
         // Update King Safety calculations
-        if ((attacks &= ei->kingAreas[THEM])) {
+        if ((attacks &= ei->kingAreas[THEM] & ~ei->pawnAttacksBy2[THEM])) {
             ei->kingAttacksCount[US] += popcount(attacks);
             ei->kingAttackersCount[US] += 1;
             ei->kingAttackersWeight[US] += KSAttackWeight[BISHOP];
@@ -700,7 +700,7 @@ int evaluateRooks(EvalInfo *ei, Board *board, int colour) {
         if (TRACE) T.RookMobility[count][US]++;
 
         // Update King Safety calculations
-        if ((attacks &= ei->kingAreas[THEM])) {
+        if ((attacks &= ei->kingAreas[THEM] & ~ei->pawnAttacksBy2[THEM])) {
             ei->kingAttacksCount[US] += popcount(attacks);
             ei->kingAttackersCount[US] += 1;
             ei->kingAttackersWeight[US] += KSAttackWeight[ROOK];
@@ -741,7 +741,7 @@ int evaluateQueens(EvalInfo *ei, Board *board, int colour) {
         if (TRACE) T.QueenMobility[count][US]++;
 
         // Update King Safety calculations
-        if ((attacks &= ei->kingAreas[THEM])) {
+        if ((attacks &= ei->kingAreas[THEM] & ~ei->pawnAttacksBy2[THEM])) {
             ei->kingAttacksCount[US] += popcount(attacks);
             ei->kingAttackersCount[US] += 1;
             ei->kingAttackersWeight[US] += KSAttackWeight[QUEEN];
@@ -1168,12 +1168,14 @@ void initEvalInfo(EvalInfo *ei, Board *board, PKTable *pktable) {
     uint64_t kings   = board->pieces[KING  ];
 
     // Save some general information about the pawn structure for later
-    ei->pawnAttacks[WHITE]  = pawnAttackSpan(white & pawns, ~0ull, WHITE);
-    ei->pawnAttacks[BLACK]  = pawnAttackSpan(black & pawns, ~0ull, BLACK);
-    ei->rammedPawns[WHITE]  = pawnAdvance(black & pawns, ~(white & pawns), BLACK);
-    ei->rammedPawns[BLACK]  = pawnAdvance(white & pawns, ~(black & pawns), WHITE);
-    ei->blockedPawns[WHITE] = pawnAdvance(white | black, ~(white & pawns), BLACK);
-    ei->blockedPawns[BLACK] = pawnAdvance(white | black, ~(black & pawns), WHITE);
+    ei->pawnAttacks[WHITE]    = pawnAttackSpan(white & pawns, ~0ull, WHITE);
+    ei->pawnAttacks[BLACK]    = pawnAttackSpan(black & pawns, ~0ull, BLACK);
+    ei->pawnAttacksBy2[WHITE] = pawnAttackDouble(white & pawns, ~0ull, WHITE);
+    ei->pawnAttacksBy2[BLACK] = pawnAttackDouble(black & pawns, ~0ull, BLACK);
+    ei->rammedPawns[WHITE]    = pawnAdvance(black & pawns, ~(white & pawns), BLACK);
+    ei->rammedPawns[BLACK]    = pawnAdvance(white & pawns, ~(black & pawns), WHITE);
+    ei->blockedPawns[WHITE]   = pawnAdvance(white | black, ~(white & pawns), BLACK);
+    ei->blockedPawns[BLACK]   = pawnAdvance(white | black, ~(black & pawns), WHITE);
 
     // Compute an area for evaluating our King's safety.
     // The definition of the King Area can be found in masks.c

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -102,6 +102,7 @@ struct EvalTrace {
 
 struct EvalInfo {
     uint64_t pawnAttacks[COLOUR_NB];
+    uint64_t pawnAttacksBy2[COLOUR_NB];
     uint64_t rammedPawns[COLOUR_NB];
     uint64_t blockedPawns[COLOUR_NB];
     uint64_t kingAreas[COLOUR_NB];

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.96"
+#define VERSION_ID "11.97"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Inspired by Vizvezdenec's patch for Stockfish.

ELO   | 3.12 +- 2.45 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 37600 W: 9351 L: 9013 D: 19236
http://chess.grantnet.us/viewTest/4725/

ELO   | 2.38 +- 1.80 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 56428 W: 11335 L: 10949 D: 34144
http://chess.grantnet.us/viewTest/4728/

BENCH : 6,225,718