### PR TITLE
Make space a separate function, update README and uci-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Most GUIs should support a method to set each option. If they do not, then refer
 
 ### Hash
 
-The size of the hash table in megabytes. For analysis the more hash given the better. For testing against other engines, just be sure to give each engine the same amount of Hash. For testing against non-classical engines, reach out to me and I will make a recommendation.
+The size of the hash table in megabytes. For analysis the more hash given the better. For testing against other engines, just be sure to give each engine the same amount of Hash. 64MB/thread/minute is generally a good value. For testing against non-classical engines, reach out to me and I will make a recommendation.
 
 ### Threads
 
@@ -28,6 +28,14 @@ Number of threads given to Ethereal while moving. Typically the more threads the
 ### MultiPV
 
 The number of lines to output for each search iteration. For best performance, MultiPV should be left at the default value of 1 in all cases. This option should only be used for analysis.
+
+### ContemptDrawPenalty
+
+The number of centipawns added to the evaluation of the side to move. A positive value incentivizes preferring slightly negative evaluations to forced draws and leads to more decisive games. A small positive value is recommended in most situations.
+
+### ContemptComplexity
+
+The number of centipawns added to the evaluation of the side to move when all minor and major pieces are on the board, progressively reduced to zero with less pieces. A positive value incentivizes Ethereal to favor lines where the opponent cannot force simplifications as easily and leads to more decisive games. It is expected to hurt performance against significantly stronger engines, but to help against weaker engines. The optimal value for best results thus depends on conditions.
 
 ### MoveOverhead
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -79,9 +79,6 @@ struct EvalTrace {
     int PassedEnemyDistance[8][COLOUR_NB];
     int PassedSafePromotionPath[COLOUR_NB];
     int PassedStacked[8][COLOUR_NB];
-    int ThreatRestrictPiece[COLOUR_NB];
-    int ThreatRestrictEmpty[COLOUR_NB];
-    int ThreatCenterControl[COLOUR_NB];
     int ThreatWeakPawn[COLOUR_NB];
     int ThreatMinorAttackedByPawn[COLOUR_NB];
     int ThreatMinorAttackedByMinor[COLOUR_NB];
@@ -92,6 +89,9 @@ struct EvalTrace {
     int ThreatQueenAttackedByOne[COLOUR_NB];
     int ThreatOverloadedPieces[COLOUR_NB];
     int ThreatByPawnPush[COLOUR_NB];
+    int SpaceRestrictPiece[COLOUR_NB];
+    int SpaceRestrictEmpty[COLOUR_NB];
+    int SpaceCenterControl[COLOUR_NB];
     int ClosednessKnightAdjustment[9][COLOUR_NB];
     int ClosednessRookAdjustment[9][COLOUR_NB];
     int ComplexityTotalPawns[COLOUR_NB];
@@ -132,6 +132,7 @@ int evaluateQueens(EvalInfo *ei, Board *board, int colour);
 int evaluateKings(EvalInfo *ei, Board *board, int colour);
 int evaluatePassed(EvalInfo *ei, Board *board, int colour);
 int evaluateThreats(EvalInfo *ei, Board *board, int colour);
+int evaluateSpace(EvalInfo *ei, Board *board, int colour);
 int evaluateClosedness(EvalInfo *ei, Board *board);
 int evaluateComplexity(EvalInfo *ei, Board *board, int eval);
 int evaluateScaleFactor(Board *board, int eval);

--- a/src/texel.c
+++ b/src/texel.c
@@ -83,9 +83,6 @@ extern const int PassedFriendlyDistance[8];
 extern const int PassedEnemyDistance[8];
 extern const int PassedSafePromotionPath;
 extern const int PassedStacked[8];
-extern const int ThreatRestrictPiece;
-extern const int ThreatRestrictEmpty;
-extern const int ThreatCenterControl;
 extern const int ThreatWeakPawn;
 extern const int ThreatMinorAttackedByPawn;
 extern const int ThreatMinorAttackedByMinor;
@@ -96,6 +93,9 @@ extern const int ThreatRookAttackedByKing;
 extern const int ThreatQueenAttackedByOne;
 extern const int ThreatOverloadedPieces;
 extern const int ThreatByPawnPush;
+extern const int SpaceRestrictPiece;
+extern const int SpaceRestrictEmpty;
+extern const int SpaceCenterControl;
 extern const int ClosednessKnightAdjustment[9];
 extern const int ClosednessRookAdjustment[9];
 extern const int ComplexityTotalPawns;
@@ -226,7 +226,7 @@ void initTexelEntries(TexelEntry *tes, Thread *thread) {
         // Vectorize the evaluation coefficients and save the eval
         // relative to WHITE. We must first clear the coeff vector.
         T = EmptyTrace;
-        tes[i].eval = evaluateBoard(&thread->board, NULL);
+        tes[i].eval = evaluateBoard(&thread->board, NULL, 0);
         if (thread->board.turn == BLACK) tes[i].eval *= -1;
         initCoefficients(coeffs);
 

--- a/src/texel.h
+++ b/src/texel.h
@@ -77,9 +77,6 @@
 #define TunePassedEnemyDistance         (0)
 #define TunePassedSafePromotionPath     (0)
 #define TunePassedStacked               (0)
-#define TuneThreatRestrictPiece         (0)
-#define TuneThreatRestrictEmpty         (0)
-#define TuneThreatCenterControl         (0)
 #define TuneThreatWeakPawn              (0)
 #define TuneThreatMinorAttackedByPawn   (0)
 #define TuneThreatMinorAttackedByMinor  (0)
@@ -90,6 +87,9 @@
 #define TuneThreatQueenAttackedByOne    (0)
 #define TuneThreatOverloadedPieces      (0)
 #define TuneThreatByPawnPush            (0)
+#define TuneSpaceRestrictPiece          (0)
+#define TuneSpaceRestrictEmpty          (0)
+#define TuneSpaceCenterControl          (0)
 #define TuneClosednessKnightAdjustment  (0)
 #define TuneClosednessRookAdjustment    (0)
 #define TuneComplexityTotalPawns        (0)
@@ -275,9 +275,6 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_1(fname, PassedEnemyDistance, 8, NORMAL);            \
     ENABLE_0(fname, PassedSafePromotionPath, NORMAL);           \
     ENABLE_1(fname, PassedStacked, 8, NORMAL);                  \
-    ENABLE_0(fname, ThreatRestrictPiece, NORMAL);               \
-    ENABLE_0(fname, ThreatRestrictEmpty, NORMAL);               \
-    ENABLE_0(fname, ThreatCenterControl, NORMAL);               \
     ENABLE_0(fname, ThreatWeakPawn, NORMAL);                    \
     ENABLE_0(fname, ThreatMinorAttackedByPawn, NORMAL);         \
     ENABLE_0(fname, ThreatMinorAttackedByMinor, NORMAL);        \
@@ -288,6 +285,9 @@ void printParameters_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, i
     ENABLE_0(fname, ThreatQueenAttackedByOne, NORMAL);          \
     ENABLE_0(fname, ThreatOverloadedPieces, NORMAL);            \
     ENABLE_0(fname, ThreatByPawnPush, NORMAL);                  \
+    ENABLE_0(fname, SpaceRestrictPiece, NORMAL);                \
+    ENABLE_0(fname, SpaceRestrictEmpty, NORMAL);                \
+    ENABLE_0(fname, SpaceCenterControl, NORMAL);                \
     ENABLE_1(fname, ClosednessKnightAdjustment, 9, NORMAL);     \
     ENABLE_1(fname, ClosednessRookAdjustment, 9, NORMAL);       \
     ENABLE_0(fname, ComplexityTotalPawns, EGONLY);              \

--- a/src/uci.c
+++ b/src/uci.c
@@ -83,12 +83,12 @@ int main(int argc, char **argv) {
 
         if (strEquals(str, "uci")) {
             printf("id name Ethereal " ETHEREAL_VERSION "\n");
-            printf("id author Andrew Grant & Laldon\n");
+            printf("id author Andrew Grant, Alayan & Laldon\n");
             printf("option name Hash type spin default 16 min 1 max 65536\n");
             printf("option name Threads type spin default 1 min 1 max 2048\n");
             printf("option name MultiPV type spin default 1 min 1 max 256\n");
-            printf("option name ContemptDrawPenalty type spin default 0 min -300 max 300\n");
-            printf("option name ContemptComplexity type spin default 0 min -100 max 100\n");
+            printf("option name ContemptDrawPenalty type spin default 12 min -300 max 300\n");
+            printf("option name ContemptComplexity type spin default 12 min -100 max 100\n");
             printf("option name MoveOverhead type spin default 100 min 0 max 10000\n");
             printf("option name SyzygyPath type string default <empty>\n");
             printf("option name SyzygyProbeDepth type spin default 0 min 0 max 127\n");

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.97"
+#define VERSION_ID "11.98"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
The 'piece restriction' and 'center control' eval terms didn't fit well in the threats function, a separate space function makes for a clearer organization.

Also fixes the missing contempt parameter in the tuner's evaluateBoard call.

Passed non-regression:
ELO   | 2.40 +- 2.65 (95%)
SPRT  | 3+0.03s Threads=1 Hash=4MB
LLR   | 2.96 (-2.94, 2.94) [-2.00, 0.00]
Games | N: 39402 W: 11887 L: 11615 D: 15900
http://chess.grantnet.us/viewTest/4736/

NO FUNCTIONAL CHANGE

BENCH : 6,225,718