### PR TITLE
Small eval randomization for drawn terminal nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -237,10 +237,9 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
     // the RootNode, since this would prevent us from having a best move
     if (!RootNode) {
 
-        // Check for the fifty move rule, a draw by
-        // repetition, or insufficient mating material
-        if (boardIsDrawn(board, height))
-            return 0;
+        // Draw Detection. Check for the fifty move rule, repetition, or insufficient 
+        // material. Add variance to the draw score, to avoid blindness to 3-fold lines
+        if (boardIsDrawn(board, height)) return 1 - (thread->nodes & 2);
 
         // Check to see if we have exceeded the maxiumum search draft
         if (height >= MAX_PLY)
@@ -602,10 +601,9 @@ int qsearch(Thread *thread, PVariation *pv, int alpha, int beta, int height) {
     if (ABORT_SIGNAL || (terminateSearchEarly(thread) && !IS_PONDERING))
         longjmp(thread->jbuffer, 1);
 
-    // Step 2. Draw Detection. Check for the fifty move rule,
-    // a draw by repetition, or insufficient mating material
-    if (boardIsDrawn(board, height))
-        return 0;
+    // Step 2. Draw Detection. Check for the fifty move rule, repetition, or insufficient 
+    // material. Add variance to the draw score, to avoid blindness to 3-fold lines
+    if (boardIsDrawn(board, height)) return 1 - (thread->nodes & 2);
 
     // Step 3. Max Draft Cutoff. If we are at the maximum search draft,
     // then end the search here with a static eval of the current board

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "11.99"
+#define VERSION_ID "12.00"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Idea from Stockfish.

The small randomization, using the thread's node count, ensures that when different potential 3-fold lines are available, the search keeps exploring different lines. This helps to discover lines where one side can escape the 3-fold with advantage. This is especially useful at longer TCs.

ELO   | 1.28 +- 2.10 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | -0.43 (-2.94, 2.94) [0.00, 4.00]
Games | N: 49920 W: 11997 L: 11813 D: 26110
http://chess.grantnet.us/viewTest/4797/

ELO   | 3.63 +- 2.88 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21050 W: 4092 L: 3872 D: 13086
http://chess.grantnet.us/viewTest/4799/

BENCH : 5,132,900