### PR TITLE
Fix TB scores in TT

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -279,8 +279,8 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
 
         // Convert the WDL value to a score. We consider blessed losses
         // and cursed wins to be a draw, and thus set value to zero.
-        value = tbresult == TB_LOSS ? -MATE + MAX_PLY + height + 1
-              : tbresult == TB_WIN  ?  MATE - MAX_PLY - height - 1 : 0;
+        value = tbresult == TB_LOSS ? -TBWIN + height + 1
+              : tbresult == TB_WIN  ?  TBWIN - height - 1 : 0;
 
         // Identify the bound based on WDL scores. For wins and losses the
         // bound is not exact because we are dependent on the height, but
@@ -293,7 +293,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
             || (ttBound == BOUND_LOWER && value >= beta)
             || (ttBound == BOUND_UPPER && value <= alpha)) {
 
-            storeTTEntry(board->hash, NONE_MOVE, value, VALUE_NONE, depth, ttBound);
+            storeTTEntry(board->hash, NONE_MOVE, valueToTT(value, height), VALUE_NONE, depth, ttBound);
             return value;
         }
     }
@@ -401,7 +401,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
 
         // Step 11 (~175 elo). Quiet Move Pruning. Prune any quiet move that meets one
         // of the criteria below, only after proving a non mated line exists
-        if (isQuiet && best > MATED_IN_MAX) {
+        if (isQuiet && best > -MATE_IN_MAX) {
 
             // Step 11A (~3 elo). Futility Pruning. If our score is far below alpha,
             // and we don't expect anything from this move, we can skip all other quiets
@@ -440,7 +440,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
         // Step 12 (~42 elo). Static Exchange Evaluation Pruning. Prune moves which fail
         // to beat a depth dependent SEE threshold. The use of movePicker.stage
         // is a speedup, which assumes that good noisy moves have a positive SEE
-        if (    best > MATED_IN_MAX
+        if (    best > -MATE_IN_MAX
             &&  depth <= SEEPruningDepth
             &&  movePicker.stage > STAGE_GOOD_NOISY
             && !staticExchangeEvaluation(board, move, seeMargin[isQuiet]))

--- a/src/search.c
+++ b/src/search.c
@@ -279,8 +279,8 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
 
         // Convert the WDL value to a score. We consider blessed losses
         // and cursed wins to be a draw, and thus set value to zero.
-        value = tbresult == TB_LOSS ? -TBWIN + height + 1
-              : tbresult == TB_WIN  ?  TBWIN - height - 1 : 0;
+        value = tbresult == TB_LOSS ? -TBWIN + height
+              : tbresult == TB_WIN  ?  TBWIN - height : 0;
 
         // Identify the bound based on WDL scores. For wins and losses the
         // bound is not exact because we are dependent on the height, but

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -106,8 +106,8 @@ int valueFromTT(int value, int height) {
     // When probing MATE scores into the table
     // we must factor in the search height
 
-    return value >=  MATE_IN_MAX ? value - height
-         : value <= MATED_IN_MAX ? value + height : value;
+    return value >=  TBWIN_IN_MAX ? value - height
+         : value <= -TBWIN_IN_MAX ? value + height : value;
 }
 
 int valueToTT(int value, int height) {
@@ -115,8 +115,8 @@ int valueToTT(int value, int height) {
     // When storing MATE scores into the table
     // we must factor in the search height
 
-    return value >=  MATE_IN_MAX ? value + height
-         : value <= MATED_IN_MAX ? value - height : value;
+    return value >=  TBWIN_IN_MAX ? value + height
+         : value <= -TBWIN_IN_MAX ? value - height : value;
 }
 
 void prefetchTTEntry(uint64_t hash) {

--- a/src/types.h
+++ b/src/types.h
@@ -40,10 +40,9 @@ enum {
 };
 
 enum {
-    MATE = 32000,
-    MATE_IN_MAX = MATE - MAX_PLY,
-    MATED_IN_MAX = MAX_PLY - MATE,
-    VALUE_NONE = 32001
+    MATE  = 32000 + MAX_PLY, MATE_IN_MAX  =  MATE - MAX_PLY,
+    TBWIN = 31000 + MAX_PLY, TBWIN_IN_MAX = TBWIN - MAX_PLY,
+    VALUE_NONE = MATE + 1
 };
 
 enum {

--- a/src/uci.c
+++ b/src/uci.c
@@ -354,11 +354,11 @@ void uciReport(Thread *threads, int alpha, int beta, int value) {
 
     // If the score is MATE or MATED in X, convert to X
     int score   = bounded >=  MATE_IN_MAX ?  (MATE - bounded + 1) / 2
-                : bounded <= MATED_IN_MAX ? -(bounded + MATE)     / 2 : bounded;
+                : bounded <= -MATE_IN_MAX ? -(bounded + MATE)     / 2 : bounded;
 
     // Two possible score types, mate and cp = centipawns
     char *type  = bounded >=  MATE_IN_MAX ? "mate"
-                : bounded <= MATED_IN_MAX ? "mate" : "cp";
+                : bounded <= -MATE_IN_MAX ? "mate" : "cp";
 
     // Partial results from a windowed search have bounds
     char *bound = bounded >=  beta ? " lowerbound "

--- a/src/uci.c
+++ b/src/uci.c
@@ -357,8 +357,7 @@ void uciReport(Thread *threads, int alpha, int beta, int value) {
                 : bounded <= -MATE_IN_MAX ? -(bounded + MATE)     / 2 : bounded;
 
     // Two possible score types, mate and cp = centipawns
-    char *type  = bounded >=  MATE_IN_MAX ? "mate"
-                : bounded <= -MATE_IN_MAX ? "mate" : "cp";
+    char *type  = abs(bounded) >= MATE_IN_MAX ? "mate" : "cp";
 
     // Partial results from a windowed search have bounds
     char *bound = bounded >=  beta ? " lowerbound "

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.06"
+#define VERSION_ID "12.07"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Tablebase win/loss scores take distance from root into account, but this was not factored in when storing them in the transposition table. This meant that the same position encountered at a different height would be given the same score as the first time it was seen, making it harder for the search to tell which path is better.

With this change Ethereal no longer has problems finding mates while using tablebases.

Also cleaned up the score enum.