### PR TITLE
Disable history updates if at depth 1the 1st quiet failed high

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -40,6 +40,20 @@ void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int he
     int fmPiece = thread->pieceStack[height-2];
     int fmTo = MoveTo(follow);
 
+    // Update Killer Moves (Avoid duplicates)
+    if (thread->killers[height][0] != bestMove) {
+        thread->killers[height][1] = thread->killers[height][0];
+        thread->killers[height][0] = bestMove;
+    }
+
+    // Update Counter Moves (BestMove refutes the previous move)
+    if (counter != NONE_MOVE && counter != NULL_MOVE)
+        thread->cmtable[!colour][cmPiece][cmTo] = bestMove;
+
+    // If the 1st quiet move failed-high at depth 1, we don't update history tables
+    // Depth 0 gives no bonus in any case
+    if (length == 1 && bonus <= 1) return;
+
     // Cap update size to avoid saturation
     bonus = MIN(bonus, HistoryMax);
 
@@ -72,16 +86,6 @@ void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int he
             thread->continuation[1][fmPiece][fmTo][piece][to] = entry;
         }
     }
-
-    // Update Killer Moves (Avoid duplicates)
-    if (thread->killers[height][0] != bestMove) {
-        thread->killers[height][1] = thread->killers[height][0];
-        thread->killers[height][0] = bestMove;
-    }
-
-    // Update Counter Moves (BestMove refutes the previous move)
-    if (counter != NONE_MOVE && counter != NULL_MOVE)
-        thread->cmtable[!colour][cmPiece][cmTo] = bestMove;
 }
 
 void updateKillerMoves(Thread *thread, int height, uint16_t move) {

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.21"
+#define VERSION_ID "12.22"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Depth 1 results are notoriously noisy, and history updates are dominated by fail-highs happening on the first quiet tried. However, if a quiet move is already ordered first, then boosting it isn't as useful, though it was shown that not updating at all on 1st quiet tried no matter the depth loses a lot of elo. This combination of conditions appears to avoid excess.

This result opens the road to explore more related changes :
- Giving a bigger bonus to history updates happening with multiple quiets tried and/or reducing the bonus when only one quiet has been tried.
- Tweaks to low-depth history updates.

ELO   | 1.95 +- 1.37 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 86841 W: 15524 L: 15037 D: 56280
http://chess.grantnet.us/test/6258/

ELO   | 6.19 +- 3.83 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8081 W: 1109 L: 965 D: 6007
http://chess.grantnet.us/test/6265/

BENCH : 5,261,405