### PR TITLE
Also disable depth 2 history updates if 1st quiet failed high

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -25,9 +25,9 @@
 #include "thread.h"
 #include "types.h"
 
-void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int height, int bonus) {
+void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int height, int depth) {
 
-    int entry, colour = thread->board.turn;
+    int entry, bonus, colour = thread->board.turn;
     uint16_t bestMove = moves[length-1];
 
     // Extract information from last move
@@ -50,12 +50,12 @@ void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int he
     if (counter != NONE_MOVE && counter != NULL_MOVE)
         thread->cmtable[!colour][cmPiece][cmTo] = bestMove;
 
-    // If the 1st quiet move failed-high at depth 1, we don't update history tables
+    // If the 1st quiet move failed-high at depth 1 or 2, we don't update history tables
     // Depth 0 gives no bonus in any case
-    if (length == 1 && bonus <= 1) return;
+    if (length == 1 && depth <= 2) return;
 
     // Cap update size to avoid saturation
-    bonus = MIN(bonus, HistoryMax);
+    bonus = MIN(depth*depth, HistoryMax);
 
     for (int i = 0; i < length; i++) {
 

--- a/src/history.h
+++ b/src/history.h
@@ -26,7 +26,7 @@ static const int HistoryMax = 400;
 static const int HistoryMultiplier = 32;
 static const int HistoryDivisor = 512;
 
-void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int height, int bonus);
+void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int height, int depth);
 void updateKillerMoves(Thread *thread, int height, uint16_t move);
 
 void getHistory(Thread *thread, uint16_t move, int height, int *hist, int *cmhist, int *fmhist);

--- a/src/search.c
+++ b/src/search.c
@@ -574,7 +574,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, int h
 
     // Step 19 (~760 elo). Update History counters on a fail high for a quiet move
     if (best >= beta && !moveIsTactical(board, bestMove))
-        updateHistoryHeuristics(thread, quietsTried, quietsPlayed, height, depth*depth);
+        updateHistoryHeuristics(thread, quietsTried, quietsPlayed, height, depth);
 
     // Step 20. Store results of search into the Transposition Table. We do
     // not overwrite the Root entry from the first line of play we examined

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.22"
+#define VERSION_ID "12.23"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO   | 0.69 +- 1.69 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 56672 W: 10033 L: 9921 D: 36718
http://chess.grantnet.us/test/6299/

ELO   | 3.11 +- 2.25 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 22672 W: 2912 L: 2709 D: 17051
http://chess.grantnet.us/test/6300/

BENCH : 5,084,619