### PR TITLE
Disable depth 3 history updates if the 1st quiet failed high

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -50,9 +50,9 @@ void updateHistoryHeuristics(Thread *thread, uint16_t *moves, int length, int he
     if (counter != NONE_MOVE && counter != NULL_MOVE)
         thread->cmtable[!colour][cmPiece][cmTo] = bestMove;
 
-    // If the 1st quiet move failed-high at depth 1 or 2, we don't update history tables
+    // If the 1st quiet move failed-high below depth 4, we don't update history tables
     // Depth 0 gives no bonus in any case
-    if (length == 1 && depth <= 2) return;
+    if (length == 1 && depth <= 3) return;
 
     // Cap update size to avoid saturation
     bonus = MIN(depth*depth, HistoryMax);

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.23"
+#define VERSION_ID "12.24"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
This is a continuation of the two previous commits on history updates. This patch didn't pass SPRT bounds directly, however over the course of a vast amount of games it established a good likelihood of superiority over the previous version. Because this is only a minor parameter tweak to a recently introduced change, with very low odds of a meaningful regression, Andrew and I felt that commiting it is the better choice.

Depth 4 was tested against depth 2 and showed a clear regression at STC.

ELO   | 0.45 +- 1.43 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | -3.05 (-2.94, 2.94) [0.00, 4.00]
Games | N: 79040 W: 13936 L: 13833 D: 51271
http://chess.grantnet.us/test/6320/

ELO   | 0.82 +- 1.03 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | -0.39 (-2.94, 2.94) [0.00, 4.00]
Games | N: 110356 W: 14082 L: 13821 D: 82453
http://chess.grantnet.us/test/6322/

A test of the cumulative changes between this version and Ethereal 12.21, the last version before this serie of history patches, has also been done :

ELO   | 5.15 +- 2.23 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 9.22 (-9.21, 9.21) [0.00, 8.00]
Games | N: 23563 W: 3156 L: 2807 D: 17600
http://chess.grantnet.us/test/6329/

BENCH : 4,555,163