### PR TITLE
Penalize queens with one or no piece between them and an enemy slider

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -69,6 +69,7 @@ struct EvalTrace {
     int RookFile[2][COLOUR_NB];
     int RookOnSeventh[COLOUR_NB];
     int RookMobility[15][COLOUR_NB];
+    int QueenRelativePin[COLOUR_NB];
     int QueenMobility[28][COLOUR_NB];
     int KingPawnFileProximity[8][COLOUR_NB];
     int KingDefenders[12][COLOUR_NB];

--- a/src/masks.c
+++ b/src/masks.c
@@ -155,6 +155,19 @@ int openFileCount(uint64_t pawns) {
     return popcount(~pawns & 0xFF);
 }
 
+// Returns 1 if the queen square is either under direct enemy slider attack
+//           or if there is only one piece (friendly or enemy) blocking the attack.
+int queenIsSliderTarget(int queenSq, uint64_t occupied, uint64_t enemyRooks, uint64_t enemyBishops) {
+
+    uint64_t rookPins = rookAttacks(queenSq, occupied & ~rookAttacks(queenSq, occupied));
+    if (rookPins & enemyRooks) return 1;
+
+    uint64_t bishopPins = bishopAttacks(queenSq, occupied & ~bishopAttacks(queenSq, occupied));
+    if (bishopPins & enemyBishops) return 1;
+
+    return 0;
+}
+
 uint64_t bitsBetweenMasks(int s1, int s2) {
     assert(0 <= s1 && s1 < SQUARE_NB);
     assert(0 <= s2 && s2 < SQUARE_NB);

--- a/src/masks.h
+++ b/src/masks.h
@@ -27,6 +27,7 @@ void initMasks();
 int distanceBetween(int sq1, int sq2);
 int kingPawnFileDistance(uint64_t pawns, int ksq);
 int openFileCount(uint64_t pawns);
+int queenIsSliderTarget(int queenSq, uint64_t occupied, uint64_t enemyRooks, uint64_t enemyBishops);
 uint64_t bitsBetweenMasks(int sq1, int sq2);
 uint64_t kingAreaMasks(int colour, int sq);
 uint64_t forwardRanksMasks(int colour, int rank);

--- a/src/texel.c
+++ b/src/texel.c
@@ -73,6 +73,7 @@ extern const int BishopMobility[14];
 extern const int RookFile[2];
 extern const int RookOnSeventh;
 extern const int RookMobility[15];
+extern const int QueenRelativePin;
 extern const int QueenMobility[28];
 extern const int KingDefenders[12];
 extern const int KingPawnFileProximity[8];

--- a/src/texel.h
+++ b/src/texel.h
@@ -24,13 +24,13 @@
 
 #define NPARTITIONS  (     64) // Total thread partitions
 #define KPRECISION   (     10) // Iterations for computing K
-#define REPORTING    (    100) // How often to report progress
-#define NTERMS       (      0) // Total terms in the Tuner (647)
+#define REPORTING    (     50) // How often to report progress
+#define NTERMS       (      0) // Total terms in the Tuner (648)
 
 #define LEARNING     (    5.0) // Learning rate
 #define LRDROPRATE   (   1.25) // Cut LR by this each failure
 #define BATCHSIZE    (  16384) // FENs per mini-batch
-#define NPOSITIONS   (5888224) // Total FENS in the book
+#define NPOSITIONS   (5832688) // Total FENS in the book
 
 #define STACKSIZE ((int)((double) NPOSITIONS * NTERMS / 32))
 
@@ -64,6 +64,7 @@
 #define TuneRookFile                    (0)
 #define TuneRookOnSeventh               (0)
 #define TuneRookMobility                (0)
+#define TuneQueenRelativePin            (0)
 #define TuneQueenMobility               (0)
 #define TuneKingDefenders               (0)
 #define TuneKingPawnFileProximity       (0)
@@ -261,6 +262,7 @@ void print_3(char *name, int params[NTERMS][PHASE_NB], int i, int A, int B, int 
     ENABLE_1(F, RookFile, 2, NORMAL, "[2]");                                \
     ENABLE_0(F, RookOnSeventh, NORMAL, "");                                 \
     ENABLE_1(F, RookMobility, 15, NORMAL, "[15]");                          \
+    ENABLE_0(F, QueenRelativePin, NORMAL, "");                              \
     ENABLE_1(F, QueenMobility, 28, NORMAL, "[28]");                         \
     ENABLE_1(F, KingDefenders, 12, NORMAL, "[12]");                         \
     ENABLE_1(F, KingPawnFileProximity, 8, NORMAL, "[FILE_NB]");             \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.26"
+#define VERSION_ID "12.27"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
The slider attacks on queen routine was contributed by Andrew. The initial idea behind this patch was to penalize queens that either are potential discovered attack targets, or that are only protected from an enemy slider attack by a friendly piece.

The current code however also adds an extra penalty for direct slider attacks on queen. This adds to the generic attack on queen penalty that also applies for knight and pawn attacks on queen. While unintended, this might contribute to the measured elo gain, as a slider's attack restricts more the queen's escape squares.

The tuner suggested only very mild values (-1, -2), the values used in this test were the 2nd attempt at guessing better ones. This might suggest that the patch's main benefit is to focus search in more critical lines.

Further work could involve trying to split the direct attack penalty from the case with a blocking piece, testing a different handling with a friendly or enemy blocking piece, refining conditions (e.g. excluding cases where the intermediate piece is a safe or blocked pawn), and tuning values.

ELO   | 2.15 +- 1.60 (95%)
SPRT  | 12.0+0.12s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 64560 W: 11741 L: 11342 D: 41477
http://chess.grantnet.us/test/6397/

ELO   | 4.22 +- 3.00 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13168 W: 1762 L: 1602 D: 9804
http://chess.grantnet.us/test/6399/

BENCH : 4,478,903