### PR TITLE
Account for MoveOverhead in time management

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -24,7 +24,7 @@
 #include "types.h"
 #include "uci.h"
 
-int MoveOverhead = 250; // Set by UCI options
+int MoveOverhead = 100; // Set by UCI options
 
 double getRealTime() {
 #if defined(_WIN32) || defined(_WIN64)
@@ -56,16 +56,16 @@ void initTimeManagment(SearchInfo *info, Limits *limits) {
 
         // Playing using X / Y + Z time control
         if (limits->mtg >= 0) {
-            info->idealUsage =  0.75 * limits->time / (limits->mtg +  5) + limits->inc;
-            info->maxAlloc   =  4.00 * limits->time / (limits->mtg +  7) + limits->inc;
-            info->maxUsage   = 10.00 * limits->time / (limits->mtg + 10) + limits->inc;
+            info->idealUsage =  0.75 * (limits->time - MoveOverhead) / (limits->mtg +  5) + limits->inc;
+            info->maxAlloc   =  4.00 * (limits->time - MoveOverhead) / (limits->mtg +  7) + limits->inc;
+            info->maxUsage   = 10.00 * (limits->time - MoveOverhead) / (limits->mtg + 10) + limits->inc;
         }
 
         // Playing using X + Y time controls
         else {
-            info->idealUsage =  1.00 * (limits->time + 25 * limits->inc) / 50;
-            info->maxAlloc   =  5.00 * (limits->time + 25 * limits->inc) / 50;
-            info->maxUsage   = 10.00 * (limits->time + 25 * limits->inc) / 50;
+            info->idealUsage =  1.00 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
+            info->maxAlloc   =  5.00 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
+            info->maxUsage   = 10.00 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
         }
 
         // Cap time allocations using the move overhead

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.53"
+#define VERSION_ID "12.54"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Before this patch, Ethereal would use its time assuming it could use all the reported time. But in sudden death, micro-increment, and no-increment repeating ; this would make the remaining time go below the MoveOverhead limit much faster. Ethereal would then play very weak moves to play as quickly as possible.

By counting the MoveOverhead time as not being usable, the drop in strength from playing instant moves is pushed back or entirely avoided.

The default MoveOverhead is also changed from 250ms to 100ms.

The first 3 tests were run with identical MoveOverhead to master:

ELO   | 68.43 +- 18.54 (95%)
SPRT  | 10.0+0.0s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 720 W: 258 L: 118 D: 344
http://chess.grantnet.us/test/7290/

ELO   | 13.10 +- 7.09 (95%)
SPRT  | 3.0+0.03s Threads=1 Hash=4MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 4192 W: 1034 L: 876 D: 2282
http://chess.grantnet.us/test/7292/

ELO   | 0.27 +- 1.63 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 62815 W: 11427 L: 11378 D: 40010
http://chess.grantnet.us/test/7291/

The repeating TC test also used 100ms MoveOverhead vs 250 for master:

ELO   | 34.71 +- 11.91 (95%)
SPRT  | 40/8.0s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1376 W: 358 L: 221 D: 797
http://chess.grantnet.us/test/7299/

BENCH : 4,252,536