### PR TITLE
Increase the importance of move stability in TM

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -56,14 +56,14 @@ void initTimeManagment(SearchInfo *info, Limits *limits) {
 
         // Playing using X / Y + Z time control
         if (limits->mtg >= 0) {
-            info->idealUsage =  0.75 * (limits->time - MoveOverhead) / (limits->mtg +  5) + limits->inc;
+            info->idealUsage =  0.67 * (limits->time - MoveOverhead) / (limits->mtg +  5) + limits->inc;
             info->maxAlloc   =  4.00 * (limits->time - MoveOverhead) / (limits->mtg +  7) + limits->inc;
             info->maxUsage   = 10.00 * (limits->time - MoveOverhead) / (limits->mtg + 10) + limits->inc;
         }
 
         // Playing using X + Y time controls
         else {
-            info->idealUsage =  1.00 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
+            info->idealUsage =  0.90 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
             info->maxAlloc   =  5.00 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
             info->maxUsage   = 10.00 * ((limits->time - MoveOverhead) + 25 * limits->inc) / 50;
         }

--- a/src/time.h
+++ b/src/time.h
@@ -33,5 +33,5 @@ void updateTimeManagment(SearchInfo *info, Limits *limits);
 int terminateTimeManagment(SearchInfo *info);
 int terminateSearchEarly(Thread *thread);
 
-static const double PVFactorCount  = 8;
-static const double PVFactorWeight = 0.085;
+static const double PVFactorCount  = 9;
+static const double PVFactorWeight = 0.105;

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.56"
+#define VERSION_ID "12.57"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO   | 2.25 +- 1.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 51723 W: 9647 L: 9312 D: 32764
http://chess.grantnet.us/test/7392/

ELO   | 2.76 +- 2.17 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24020 W: 3034 L: 2843 D: 18143
http://chess.grantnet.us/test/7394/

ELO   | 5.45 +- 3.94 (95%)
SPRT  | 40/8.0s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 3.00]
Games | N: 11472 W: 2297 L: 2117 D: 7058
http://chess.grantnet.us/test/7392/

BENCH : 4,277,970