### PR TITLE
Fix an off-by-one buffer overflow crash when initializing NN

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -69,7 +69,7 @@ void initPKNetwork() {
     for (int i = 0; i < PKNETWORK_LAYER1; i++) {
 
         // Grab the next line and tokenize it
-        char weights[strlen(PKWeights[i])];
+        char weights[strlen(PKWeights[i]) + 1];
         strcpy(weights, PKWeights[i]);
         strtok(weights, " ");
 
@@ -81,7 +81,7 @@ void initPKNetwork() {
     for (int i = 0; i < PKNETWORK_OUTPUTS; i++) {
 
         // Grab the next line and tokenize it
-        char weights[strlen(PKWeights[i + PKNETWORK_LAYER1])];
+        char weights[strlen(PKWeights[i + PKNETWORK_LAYER1]) + 1];
         strcpy(weights, PKWeights[i + PKNETWORK_LAYER1]);
         strtok(weights, " ");
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.58"
+#define VERSION_ID "12.59"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Buffer Overflow reproduced with following details:

kyle@kyle-ubuntu:~/Chess/Ethereal/src$ git remote -v
origin	https://github.com/AndyGrant/Ethereal.git (fetch)
origin	https://github.com/AndyGrant/Ethereal.git (push)
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ git branch
* master
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ git pull
Already up to date.
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ pwd
/home/kyle/Chess/Ethereal/src
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ make pext
gcc -O3 -std=gnu11 -Wall -Wextra -Wshadow -DNDEBUG -flto -march=native *.c pyrrhic/tbprobe.c -lpthread -lm -DUSE_POPCNT -msse3 -mpopcnt -DUSE_PEXT -mbmi2 -o Ethereal
In function ‘strcpy’,
    inlined from ‘initPKNetwork’ at network.c:85:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:90:10: warning: ‘__builtin___memcpy_chk’ writing 624 bytes into a region of size 623 overflows the destination [-Wstringop-overflow=]
   return __builtin___strcpy_chk (__dest, __src, __bos (__dest));
          ^
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/7/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 7.5.0-3ubuntu1~18.04' --with-bugurl=file:///usr/share/doc/gcc-7/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-7 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 7.5.0 (Ubuntu 7.5.0-3ubuntu1~18.04) 
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ ./Ethereal 
*** buffer overflow detected ***: ./Ethereal terminated
Aborted (core dumped)
kyle@kyle-ubuntu:~/Chess/Ethereal/src$ uname -a
Linux kyle-ubuntu 5.3.0-40-generic #32~18.04.1-Ubuntu SMP Mon Feb 3 14:05:59 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
