### PR TITLE
Introduce pawn shelter/storm arrays for king safety

### DIFF
--- a/src/evalcache.c
+++ b/src/evalcache.c
@@ -47,7 +47,8 @@ PKEntry* getCachedPawnKingEval(Thread *thread, Board *board) {
     return pke->pkhash == board->pkhash ? pke : NULL;
 }
 
-void storeCachedPawnKingEval(Thread *thread, Board *board, uint64_t passed, int eval) {
+void storeCachedPawnKingEval(Thread *thread, Board *board, uint64_t passed, int eval, int safetyw, int safetyb) {
     PKEntry *pke = &thread->pktable[board->pkhash & PK_CACHE_MASK];
-    *pke = (PKEntry) {board->pkhash, passed, eval};
+    *pke = (PKEntry) {board->pkhash, passed, eval, safetyw, safetyb};
 }
+

--- a/src/evalcache.h
+++ b/src/evalcache.h
@@ -35,11 +35,12 @@ enum {
 typedef uint64_t EvalEntry;
 typedef EvalEntry EvalTable[EVAL_CACHE_SIZE];
 
-struct PKEntry { uint64_t pkhash, passed; int eval; };
+struct PKEntry { uint64_t pkhash, passed; int eval, safetyw, safetyb; };
 typedef PKEntry PKTable[PK_CACHE_SIZE];
 
 int getCachedEvaluation(Thread *thread, Board *board, int *eval);
 void storeCachedEvaluation(Thread *thread, Board *board, int eval);
 
 PKEntry* getCachedPawnKingEval(Thread *thread, Board *board);
-void storeCachedPawnKingEval(Thread *thread, Board *board, uint64_t passed, int eval);
+void storeCachedPawnKingEval(Thread *thread, Board *board, uint64_t passed, int eval, int safetyw, int safetyb);
+

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -88,6 +88,8 @@ struct EvalTrace {
     int SafetySafeBishopCheck[COLOUR_NB];
     int SafetySafeKnightCheck[COLOUR_NB];
     int SafetyAdjustment[COLOUR_NB];
+    int SafetyShelter[2][8][COLOUR_NB];
+    int SafetyStorm[2][8][COLOUR_NB];
     int PassedPawn[2][2][8][COLOUR_NB];
     int PassedFriendlyDistance[8][COLOUR_NB];
     int PassedEnemyDistance[8][COLOUR_NB];
@@ -132,6 +134,7 @@ struct EvalInfo {
     int kingAttackersCount[COLOUR_NB];
     int kingAttackersWeight[COLOUR_NB];
     int pkeval[COLOUR_NB];
+    int pksafety[COLOUR_NB];
     PKEntry *pkentry;
 };
 
@@ -142,6 +145,7 @@ int evaluateKnights(EvalInfo *ei, Board *board, int colour);
 int evaluateBishops(EvalInfo *ei, Board *board, int colour);
 int evaluateRooks(EvalInfo *ei, Board *board, int colour);
 int evaluateQueens(EvalInfo *ei, Board *board, int colour);
+int evaluateKingsPawns(EvalInfo *ei, Board *board, int colour);
 int evaluateKings(EvalInfo *ei, Board *board, int colour);
 int evaluatePassed(EvalInfo *ei, Board *board, int colour);
 int evaluateThreats(EvalInfo *ei, Board *board, int colour);

--- a/src/tuner.c
+++ b/src/tuner.c
@@ -90,6 +90,8 @@ extern const int SafetySafeRookCheck;
 extern const int SafetySafeBishopCheck;
 extern const int SafetySafeKnightCheck;
 extern const int SafetyAdjustment;
+extern const int SafetyShelter[2][8];
+extern const int SafetyStorm[2][8];
 extern const int PassedPawn[2][2][8];
 extern const int PassedFriendlyDistance[8];
 extern const int PassedEnemyDistance[8];

--- a/src/tuner.h
+++ b/src/tuner.h
@@ -37,7 +37,7 @@
 #define TuneSafety     (        0) // Flag to enable tuning on all Safeties
 #define TuneComplexity (        0) // Flag to enable tuning on all Complexities
 
-#define NTERMS         (       0) // Total terms in the Tuner (872)
+#define NTERMS         (       0) // Total terms in the Tuner (904)
 #define MAXEPOCHS      (   10000) // Max number of epochs allowed
 #define BATCHSIZE      (   16384) // FENs per mini-batch
 #define NPOSITIONS     ( 9999740) // Total FENS in the book
@@ -91,6 +91,8 @@
 #define TuneSafetySafeBishopCheck       (0 || TuneSafety)
 #define TuneSafetySafeKnightCheck       (0 || TuneSafety)
 #define TuneSafetyAdjustment            (0 || TuneSafety)
+#define TuneSafetyShelter               (0 || TuneSafety)
+#define TuneSafetyStorm                 (0 || TuneSafety)
 #define TunePassedPawn                  (0 || TuneNormal)
 #define TunePassedFriendlyDistance      (0 || TuneNormal)
 #define TunePassedEnemyDistance         (0 || TuneNormal)
@@ -333,6 +335,8 @@ void print_3(char *name, TVector params, int i, int A, int B, int C, char *S);
     ENABLE_0(F, SafetySafeBishopCheck, SAFETY, "");                         \
     ENABLE_0(F, SafetySafeKnightCheck, SAFETY, "");                         \
     ENABLE_0(F, SafetyAdjustment, SAFETY, "     ");                         \
+    ENABLE_2(F, SafetyShelter, 2, 8, SAFETY, "[2][RANK_NB]");               \
+    ENABLE_2(F, SafetyStorm, 2, 8, SAFETY, "[2][RANK_NB]");                 \
                                                                             \
     COMMENTS(F, "\n/* Passed Pawn Evaluation Terms */\n\n");                \
     ENABLE_3(F, PassedPawn, 2, 2, 8, NORMAL, "[2][2][RANK_NB]");            \

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.59"
+#define VERSION_ID "12.60"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
The new arrays are independent of the existing big shelter and storm arrays dimensioned on file and rank and adding a fixed value to the evaluation term. The new arrays don't have file-based values.

The core idea is that the quality of the king's pawn cover or the enemy pawn storm is not a fixed advantage or disadvantage. It oftentimes depends on what else the other side has to threaten the king. By plugging the values into king safety, that has a quadratic component, we can better take into account the convergence of threats that is the true recipe for compromised king safety.

This patch increases significantly the size of each pawn-cache entry. It may be better to compute the shelter/storm safety value on each eval call instead, with the added benefit of cleaner code with it done in the main king evaluation function.

Retuning related eval terms might also show benefits.

STC was tested on the commit before the PK-NN introduction :
ELO   | 6.40 +- 4.25 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9072 W: 1694 L: 1527 D: 5851
http://chess.grantnet.us/test/7474/

LTC was rebased and tested against the latest master :
ELO   | 5.32 +- 3.38 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9404 W: 1165 L: 1021 D: 7218
http://chess.grantnet.us/test/7481/

BENCH : 4,919,336