### PR TITLE
Add support for compiling Ethereal from Raspberry Pi devices

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -33,6 +33,8 @@ ARMV8FLAGS  = -O3 $(WFLAGS) -DNDEBUG -flto -march=armv8-a -m64
 ARMV7FLAGS  = -O3 $(WFLAGS) -DNDEBUG -flto -march=armv7-a -m32
 ARMV7FLAGS += -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -Wl,--fix-cortex-a8
 
+RPIFLAGS = -O3 $(WFLAGS) -DNDEBUG -flto -march=armv8-a
+
 popcnt:
 	$(CC) $(CFLAGS) $(SRC) $(LIBS) $(POPCNTFLAGS) -o $(EXE)
 
@@ -62,3 +64,6 @@ armv8:
 
 armv7:
 	$(CC) $(ARMV7FLAGS) $(SRC) -lm -o $(EXE)
+
+rpi:
+	$(CC) $(RPIFLAGS) $(SRC) $(LIBS) -o $(EXE)

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.60"
+#define VERSION_ID "12.61"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Ethereal fails to compile on ARMv8 Raspberry Pi 4 devices.  This commit adds a new 'rpi' make command for armv8 arch that removes the -m64 cc flag and adds the -lpthread library.