### PR TITLE
Increase reductions for tactical moves with a very poor history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -522,7 +522,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth) {
         // Step 15B (~2 elo). Noisy Late Move Reductions. The same as Step 15A, but
         // only applied to Tactical moves with unusually poor Capture History scores
         else if (!isQuiet && depth > 2 && played > 1)
-            R = MIN(depth - 1, 1 + (hist <= 0));
+            R = MIN(depth - 1, MAX(1, MIN(3, 3 - (hist + 4000) / 2000)));
 
         // No LMR conditions were met. Use a Standard Reduction
         else R = 1;

--- a/src/search.h
+++ b/src/search.h
@@ -75,8 +75,8 @@ static const int LateMovePruningCounts[2][9] = {
 };
 
 static const int SEEPruningDepth = 9;
-static const int SEEQuietMargin = -55;
-static const int SEENoisyMargin = -17;
+static const int SEEQuietMargin = -64;
+static const int SEENoisyMargin = -19;
 static const int SEEPieceValues[] = {
      100,  450,  450,  675,
     1300,    0,    0,    0,

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.63"
+#define VERSION_ID "12.64"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Building upon the previous patch, we now apply a depth reduction of up to 2 (instead of up to 1) to tactical moves with a negative history, using history score thresholds for this purpose.

We also slightly relax our SEE pruning thresholds. The idea is that as Ethereal will waste less time searching poor captures, we can prune them less and have reduced searches achieve a better balance of tactical awareness and branching factor than either full pruning or full search.

This was shown to likely be slightly better than the increased reductions alone :

ELO   | 0.57 +- 1.32 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [-2.00, 2.00]
Games | N: 96920 W: 17729 L: 17571 D: 61620
http://chess.grantnet.us/test/7624/

Tests for the full patch against the previous master :

ELO   | 4.19 +- 3.24 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16320 W: 3120 L: 2923 D: 10277
http://chess.grantnet.us/test/7602/

ELO   | 4.45 +- 3.02 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12112 W: 1529 L: 1374 D: 9209
http://chess.grantnet.us/test/7633/

BENCH : 4,328,954