### PR TITLE
Remove redundant line

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -440,9 +440,7 @@ void revertMove(Board *board, uint16_t move, Undo *undo) {
 void revertNullMove(Board *board, Undo *undo) {
 
     // Revert information which is hard to recompute
-    // We may, and have to, zero out the king attacks
     board->hash            = undo->hash;
-    board->kingAttackers   = 0ull;
     board->epSquare        = undo->epSquare;
     board->halfMoveCounter = undo->halfMoveCounter;
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.66"
+#define VERSION_ID "12.67"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Can't nullmove when there are checkers, and there can't be any in the following positions (or we could have captured king. Thus setting it to 0 when taking back a nullmove is not necessary.

No functional change