### PR TITLE
Move move count pruning out of the conditional and count noisy moves as

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.75"
+#define VERSION_ID "12.77"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
ELO   | 6.31 +- 3.79 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7824 W: 1022 L: 880 D: 5922
