### PR TITLE
Adding new UCI option SkillLevel from 1 to 100

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -871,7 +871,7 @@ void applySkillVariation(Thread *thread, int multiPV) {
     // The bestMoves of the PVs are then resorted by the new PV value rankings
     //
     // Formula for calculating magnitude of the adjustment window, in centipawns:
-    // f(x) = 1000**(-(x - 99)/100) + (-6 * x + 594)
+    // f(x) = 500**(-(x - 99)/100) + (-3 * x + 297)
     //
     // The formula follows the format f(x) = exponential + linear
     // The linear term is required so there is an actual difference between skills when skill > 90
@@ -879,17 +879,18 @@ void applySkillVariation(Thread *thread, int multiPV) {
     //
     // The above formula has the following cp variances at the below skills:
     // 99 -> 1 cp
-    // 95 -> 25 cp
-    // 80 -> 118 cp
-    // 60 -> 249 cp
-    // 40 -> 413 cp
-    // 20 -> 708 cp
-    // 5  -> 1225 cp
-    // 1  -> 1459 cp
+    // 95 -> 13 cp   -> Top Human
+    // 80 -> 60 cp   -> Master
+    // 60 -> 128 cp  -> Strong online player
+    // 40 -> 216 cp  -> Average online player
+    // 20 -> 373 cp  -> Beginner
+    // 5  -> 626 cp
+    // 1  -> 736 cp  -> Monkey
     //
-    // The average online player should find Skill Level 50 a decent challenge
+    // These cp variances allow Ethereal to make positional blunders.  A search-related depth handicap is
+    // enforced based on skillLevel elsewhere to account for tactical blunders.
     
-    int variances[99] = {1459,1395,1335,1278,1225,1175,1127,1083,1041,1002,965,929,896,865,835,807,780,755,731,708,687,666,647,628,610,593,577,561,546,531,518,504,491,479,467,456,444,434,423,413,403,393,384,375,366,357,348,340,332,324,316,308,300,292,285,277,270,263,256,249,242,235,228,221,214,208,201,195,188,181,175,168,162,156,149,143,137,130,124,118,111,105,99,93,87,80,74,68,62,56,50,44,38,31,25,19,13,7,1};
+    int variances[99] = {736,706,678,651,626,603,580,559,539,519,501,484,467,452,437,423,409,397,384,373,361,351,341,331,321,312,304,295,287,280,272,265,258,252,245,239,233,227,222,216,211,206,200,196,191,186,181,177,172,168,164,160,155,151,147,143,140,136,132,128,125,121,117,114,110,107,103,100,96,93,90,86,83,80,76,73,70,67,63,60,57,54,51,48,44,41,38,35,32,29,26,23,19,16,13,10,7,4,1};
     int maxVariance = variances[thread->skill - 1];
 
     for (int i = 0; i < multiPV; i++) {

--- a/src/search.h
+++ b/src/search.h
@@ -42,6 +42,9 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth);
 int qsearch(Thread *thread, PVariation *pv, int alpha, int beta);
 int staticExchangeEvaluation(Board *board, uint16_t move, int threshold);
 int singularity(Thread *thread, MovePicker *mp, int ttValue, int depth, int beta);
+void applySkillVariation(Thread *thread, int multiPV);
+void sortMoves(Thread *thread, int lo, int hi);
+int partition(Thread *thread, int lo, int hi);
 
 static const int WindowDepth   = 5;
 static const int WindowSize    = 10;

--- a/src/thread.h
+++ b/src/thread.h
@@ -42,6 +42,7 @@ struct Thread {
     SearchInfo *info;
 
     int multiPV, values[MAX_MOVES];
+    int skill;
     uint16_t bestMoves[MAX_MOVES];
     uint16_t ponderMoves[MAX_MOVES];
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -241,6 +241,13 @@ void *uciGo(void *cargo) {
     // Set the skill level on the main thread
     threads[0].skill = skill;
 
+    // Restrict depth searched based on skill level
+    // Depth increase is linear and increases every 10 levels
+    if (skill < 100) {
+        limits.limitedByDepth = true;
+        limits.depthLimit = skill / 10 + 2;
+    }
+
     // Execute search, return best and ponder moves
     getBestMove(threads, board, &limits, &bestMove, &ponderMove);
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.87"
+#define VERSION_ID "12.88"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"
@@ -41,13 +41,14 @@ struct Limits {
 
 struct UCIGoStruct {
     int multiPV;
+    int skill;
     char str[512];
     Board *board;
     Thread *threads;
 };
 
 void *uciGo(void *cargo);
-void uciSetOption(char *str, Thread **threads, int *multiPV, int *chess960);
+void uciSetOption(char *str, Thread **threads, int *multiPV, int *chess960, int *skill);
 void uciPosition(char *str, Board *board, int chess960);
 
 void uciReport(Thread *threads, int alpha, int beta, int value);


### PR DESCRIPTION
To use SkillLevel, MultiPV will automatically be bumped up to 256 in order to implement the skill logic.
Each move in the MultiPV is given a random cp variance to ensure slight mistakes.
The magnitude of the variance is determined by the following formula, where x is the SkillLevel:

f(x) = 1000**(-(x - 99)/100) + (-6 * x + 594)

If SkillLevel is set to the default value of 100, Ethereal will not enter any of the SkillLevel logic.
Here are estimates of SkillLevel strength for a human player:

90 -> Grandmaster
80 -> Master
70 -> Tournament player
60 -> Strong online player
40 -> Average online player
20 -> Beginner

NO FUNCTIONAL CHANGE

BENCH : 4,063,377