### PR TITLE
Enforce the thread data to be aligned on a 64-byte boundary

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -33,7 +33,11 @@ int ContemptComplexity  = 0;
 
 Thread* createThreadPool(int nthreads) {
 
+#if defined(_WIN32) || defined(_WIN64)
+    Thread *threads = _aligned_malloc(nthreads * sizeof(Thread), 64);
+#else
     Thread *threads = aligned_alloc(64, nthreads * sizeof(Thread));
+#endif
 
     memset(threads, 0, nthreads * sizeof(Thread));
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -33,7 +33,9 @@ int ContemptComplexity  = 0;
 
 Thread* createThreadPool(int nthreads) {
 
-    Thread *threads = calloc(nthreads, sizeof(Thread));
+    Thread *threads = aligned_alloc(64, nthreads * sizeof(Thread));
+
+    memset(threads, 0, nthreads * sizeof(Thread));
 
     for (int i = 0; i < nthreads; i++) {
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.89"
+#define VERSION_ID "12.90"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Ethereal was allocating the thread data without enforcing the address to be aligned, as requested by the different declarations inside the structure with `ALIGN64`.
This commit uses the C11 function `aligned_alloc()` to make sure requested memory is always at least aligned on 64 bytes.

Bench: 4224732