### PR TITLE
Endgame scaling for pawns

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1313,7 +1313,17 @@ int evaluateScaleFactor(Board *board, int eval) {
         &&  popcount(strong & pawns) - popcount(weak & pawns) > 2)
         return SCALE_LARGE_PAWN_ADV;
 
-    return SCALE_NORMAL;
+    // Avoid the King + 2 Knights vs lone King draw
+    if (   !queens
+        && !rooks
+        && !bishops
+        && !pawns
+        && !several(pieces & weak)
+        && popcount(knights) == 2)
+        return SCALE_DRAW;
+
+    // Scale down as the number of pawns of the strong side reduces
+    return MIN(SCALE_NORMAL, 96 + popcount(pawns & strong) * 8);
 }
 
 void initEvalInfo(Thread *thread, Board *board, EvalInfo *ei) {

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1313,15 +1313,6 @@ int evaluateScaleFactor(Board *board, int eval) {
         &&  popcount(strong & pawns) - popcount(weak & pawns) > 2)
         return SCALE_LARGE_PAWN_ADV;
 
-    // Avoid the King + 2 Knights vs lone King draw
-    if (   !queens
-        && !rooks
-        && !bishops
-        && !pawns
-        && !several(pieces & weak)
-        && popcount(knights) == 2)
-        return SCALE_DRAW;
-
     // Scale down as the number of pawns of the strong side reduces
     return MIN(SCALE_NORMAL, 96 + popcount(pawns & strong) * 8);
 }

--- a/src/uci.h
+++ b/src/uci.h
@@ -22,7 +22,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "12.89"
+#define VERSION_ID "12.90"
 
 #if defined(USE_PEXT)
     #define ETHEREAL_VERSION VERSION_ID" (PEXT)"


### PR DESCRIPTION
Adjust scaling factor of endgames based on the remaining pawns of the strong side.

http://chess.grantnet.us/test/10924/
http://chess.grantnet.us/test/10926/