### PR TITLE
Add improving to RFP and adjust the margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -488,7 +488,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, bool 
         && !inCheck
         && !ns->excluded
         &&  depth <= BetaPruningDepth
-        &&  eval - BetaMargin * depth > beta)
+        &&  eval - BetaMargin * MAX(0, (depth - improving)) >= beta)
         return eval;
 
     // Step 8 (~3 elo). Alpha Pruning for main search loop. The idea is

--- a/src/search.h
+++ b/src/search.h
@@ -47,7 +47,7 @@ static const int CurrmoveTimerMS = 2500;
 static const int TTResearchMargin = 141;
 
 static const int BetaPruningDepth = 8;
-static const int BetaMargin = 57;
+static const int BetaMargin = 65;
 
 static const int AlphaPruningDepth = 4;
 static const int AlphaMargin = 3488;

--- a/src/uci.h
+++ b/src/uci.h
@@ -23,7 +23,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "14.25"
+#define VERSION_ID "14.28"
 
 #ifndef LICENSE_OWNER
     #define LICENSE_OWNER "Unlicensed"


### PR DESCRIPTION
LTC:
Elo   | 2.92 +- 2.81 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 26522 W: 6097 L: 5874 D: 14551
Penta | [24, 2970, 7046, 3201, 20]
http://chess.grantnet.us/test/34915/

STC:
Elo   | 1.77 +- 1.82 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 63892 W: 14858 L: 14533 D: 34501
Penta | [294, 7506, 16024, 7825, 297]
http://chess.grantnet.us/test/34904/