### PR TITLE
Removing MAX condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -698,7 +698,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, bool 
                 R -= ns->mp.stage < STAGE_QUIET;
 
                 // Adjust based on history scores
-                R -= MAX(-2, MIN(2, hist / 6167));
+                R -= MIN(2, hist / 6167);
             }
 
             // Step 18B (~3 elo). Noisy Late Move Reductions. The same as Step 18A, but


### PR DESCRIPTION
Removing MAX condition from the history reduction formula.

Passed STC (-3, 1):
Elo   | 3.53 +- 4.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 11532 W: 2743 L: 2626 D: 6163
Penta | [51, 1321, 2909, 1430, 55]
http://chess.grantnet.us/test/35030/

Passed LTC (-3, 1):
Elo   | 0.56 +- 2.24 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 41718 W: 9454 L: 9387 D: 22877
Penta | [46, 4749, 11186, 4848, 30]
http://chess.grantnet.us/test/35033/

Update: A test including both changes also passed very quickly:
Elo   | 3.53 +- 4.25 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 11806 W: 2786 L: 2666 D: 6354
Penta | [53, 1365, 2965, 1449, 71]
http://chess.grantnet.us/test/35071/

bench: 2815875