### PR TITLE
Removing MIN condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -698,7 +698,7 @@ int search(Thread *thread, PVariation *pv, int alpha, int beta, int depth, bool 
                 R -= ns->mp.stage < STAGE_QUIET;
 
                 // Adjust based on history scores
-                R -= MAX(-2, MIN(2, hist / 6167));
+                R -= MAX(-2, hist / 6167);
             }
 
             // Step 18B (~3 elo). Noisy Late Move Reductions. The same as Step 18A, but


### PR DESCRIPTION
Removing MAX condition from the history reduction formula.
When I first planned for these 2 tests, I didn't expect both of them to pass, that's why I ran them separately.
Let me know if an extra test merging both of them is needed or not.

Passed STC (-3, 1):
Elo   | -0.24 +- 1.13 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 165102 W: 37853 L: 37966 D: 89283
Penta | [762, 19648, 41823, 19577, 741]
http://chess.grantnet.us/test/35031/

Passed LTC (-3, 1):
Elo   | 2.65 +- 3.86 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 13786 W: 3111 L: 3006 D: 7669
Penta | [8, 1512, 3755, 1603, 15]
http://chess.grantnet.us/test/35036/

Update: A test including both changes also passed very quickly:
Elo   | 3.53 +- 4.25 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 11806 W: 2786 L: 2666 D: 6354
Penta | [53, 1365, 2965, 1449, 71]
http://chess.grantnet.us/test/35071/

bench: 3183511