### PR TITLE
Optimise NNUE inference code

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -23,7 +23,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "14.38"
+#define VERSION_ID "14.39"
 
 #ifndef LICENSE_OWNER
     #define LICENSE_OWNER "Unlicensed"


### PR DESCRIPTION
Remove intermediate stores between activating the accumulator and L1 affine transform.

Elo   | 7.41 +- 4.86 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9242 W: 2280 L: 2083 D: 4879
Penta | [30, 907, 2569, 1066, 49]
http://chess.grantnet.us/test/36685/

```
Dev  682949 nps
Base 672022 nps
Gain 1.626%
```

Bench 2492187