### PR TITLE
Allocate TimeManager on heap

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -196,12 +196,12 @@ void *start_search_threads(void *arguments) {
 void getBestMove(Thread *threads, Board *board, Limits *limits, uint16_t *best, uint16_t *ponder, int *score) {
 
     pthread_t pthreads[threads->nthreads];
-    TimeManager tm = {0}; tm_init(limits, &tm);
+    TimeManager *tm = create_tm(); tm_init(limits, tm);
 
     // Minor house keeping for starting a search
     tt_update(); // Table has an age component
     ABORT_SIGNAL = 0; // Otherwise Threads will exit
-    newSearchThreadPool(threads, board, limits, &tm);
+    newSearchThreadPool(threads, board, limits, tm);
 
     // Allow Syzygy to refine the move list for optimal results
     if (!limits->limitedByMoves && limits->multiPV == 1)
@@ -222,6 +222,8 @@ void getBestMove(Thread *threads, Board *board, Limits *limits, uint16_t *best, 
 
     // Pick the best of our completed threads
     select_from_threads(threads, best, ponder, score);
+
+    delete_tm(tm);
 }
 
 void* iterativeDeepening(void *vthread) {

--- a/src/timeman.c
+++ b/src/timeman.c
@@ -46,6 +46,14 @@ double elapsed_time(const TimeManager *tm) {
 }
 
 
+TimeManager *create_tm() {
+    return calloc(1, sizeof(TimeManager));
+}
+
+void delete_tm(TimeManager *tm) {
+    free(tm);
+}
+
 void tm_init(const Limits *limits, TimeManager *tm) {
 
     tm->pv_stability = 0; // Clear our stability time usage heuristic

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -39,6 +39,8 @@ struct TimeManager {
 
 double get_real_time();
 double elapsed_time(const TimeManager *tm);
+TimeManager *create_tm();
+void delete_tm(TimeManager *tm);
 void tm_init(const Limits *limits, TimeManager *tm);
 void tm_update(const Thread *thread, const Limits *limits, TimeManager *tm);
 bool tm_finished(const Thread *thread, const TimeManager *tm);

--- a/src/uci.h
+++ b/src/uci.h
@@ -23,7 +23,7 @@
 
 #include "types.h"
 
-#define VERSION_ID "14.40"
+#define VERSION_ID "14.41"
 
 #ifndef LICENSE_OWNER
     #define LICENSE_OWNER "Unlicensed"


### PR DESCRIPTION
Fix crashes on MacOS as the TM object is too large for the default 512 KB stack

Bench 2946917